### PR TITLE
Prevent the following of redirects for custom domains

### DIFF
--- a/tasks/deploy-sync.js
+++ b/tasks/deploy-sync.js
@@ -25,6 +25,7 @@ gulp.task('deploy:sync-init', function() {
   var tkConfig = yaml.safeLoad(file);
   var envObj;
   var environment;
+  var proxyTarget = '';
   var queryStringComponents = [];
 
   if (process.env.tkEnvironments) {
@@ -35,9 +36,10 @@ gulp.task('deploy:sync-init', function() {
   }
 
   envObj = tkConfig[environment];
+  proxyTarget = 'https://' + envObj.store;
 
   if (envObj.theme_id && (envObj.theme_id === parseInt(envObj.theme_id, 10))) {
-    queryStringComponents.push('preview_theme_id=' + envObj.theme_id);
+    proxyTarget += '?preview_theme_id=' + envObj.theme_id;
   }
 
   /**
@@ -48,7 +50,7 @@ gulp.task('deploy:sync-init', function() {
 
   browserSync.init({
     proxy: {
-      target: 'https://' + envObj.store,
+      target: proxyTarget,
       middleware: function(req, res, next) {
         var prefix = req.url.indexOf('?') > -1 ? '&' : '?';
         req.url += prefix + queryStringComponents.join('&');


### PR DESCRIPTION
When merchants have redirection on for custom domains, browserstack was loading the page then following the redirect to the new URL:
![image](https://cloud.githubusercontent.com/assets/1245284/17895140/1a6d06e8-691a-11e6-849e-a6eb2e7827af.png)

This PR uses a query string param in Shopify (`?_fd=0`) to prevent that forwarding. It also moves away from the generic query string proxying to using middleware, so the site can continue to be navigated and still keep that query string. 

@cshold @t-kelly 
cc @m-ux 
