### PR TITLE
Remove old onboarding states

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} Produkt",
         "other": "{{ count }} Produkte"
       }
-    },
-    "onboarding": {
-      "modal_title": "Auf dieser Seite werden alle Produkte Ihres Geschäfts angezeigt.",
-      "no_products_html": "Es sind noch keine Produkte vorhanden, doch sobald Sie welche hinzufügen, werden sie hier angezeigt, ganz gleich, ob sie zu einer Kollektion gehören oder nicht.",
-      "add_product": "Artikel hinzufügen"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Ausgewählte Zusammenstellungen"
     },
     "onboarding": {
-      "modal_title": "Fast fertig...",
-      "no_products_html": "Sie haben keine Artikel in Ihrer Startseiten-Zusammenstellung. Dieser Platzhalter verschwindet, wenn Sie <a href=\"/admin/collections?tutorial=Frontpage\">dieser Zusammenstellung einen Artikel hinzufügen</a>.",
-      "add_product": "Fügen Sie ein Produkt",
       "product_title": "Beispielhafter Produkttitel",
-      "no_collections_html": "Sie haben hier keine Zusammenstellungen zum Anzeigen. <a href=\"/admin/custom_collections\">Fügen Sie ein paar Zusammenstellungen</a> zur Standard-Startseite hinzu.",
-      "add_collection": "Fügen Sie eine Sammlung",
       "collection_title": "Beispielhafter Zusammenstellungstitel"
     }
   },

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} item",
         "other": "{{ count }} items"
       }
-    },
-     "onboarding": {
-      "modal_title": "This page will show all of your store's products",
-      "no_products_html": "There are no products yet, but once you begin adding them they will show up here regardless if they are in a collection.",
-      "add_product": "Add Product"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Featured Collections"
     },
     "onboarding": {
-      "modal_title": "Almost there...",
-      "no_products_html": "You have no products in your Frontpage collection. This placeholder will appear until you <a href=\"/admin/collections?tutorial=Frontpage\">add a product to this collection</a>.",
-      "add_product": "Add a Product",
       "product_title": "Example Product Title",
-      "no_collections_html": "You don't have any collections to show here. <a href=\"/admin/custom_collections\">Add some collections</a> to go along with the default Frontpage.",
-      "add_collection": "Add a Collection",
       "collection_title": "Example Collection Title"
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} artículo",
         "other": "{{ count }} artículos"
       }
-    },
-    "onboarding": {
-      "modal_title": "Esta página mostrará todos los productos de su tienda",
-      "no_products_html": "Todavía no hay productos pero, una vez que comience a añadirlos, se mostrarán aquí sin importar si están en una colección.",
-      "add_product": "Agregar producto"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Colecciones destacadas"
     },
     "onboarding": {
-      "modal_title": "Casi allí...",
-      "no_products_html": "No tiene productos en su colección de portada. Este indicador aparecerá hasta que <a href=\"/admin/collections?tutorial=Frontpage\">agregue un producto a esta colección</a>.",
-      "add_product": "Añadir un producto",
       "product_title": "Ejemplo título de producto",
-      "no_collections_html": "No tiene colecciones para mostrar aquí. <a href=\"/admin/custom_collections\">Agregue algunas colecciones</a> que acompañen a la Portada por defecto.",
-      "add_collection": "Añadir una colección",
       "collection_title": "Ejemplo título de colección"
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} item",
         "other": "{{ count }} items"
       }
-    },
-    "onboarding": {
-      "modal_title": "Cette page affichera tous les produits de votre magasin",
-      "no_products_html": "Il n'y a aucun produit pour l'instant, mais dès que vous commencerez à les ajouter, ils s'afficheront ici, qu'ils soient dans une collection ou non.",
-      "add_product": "Ajouter un produit"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Collections en vedette"
     },
     "onboarding": {
-      "modal_title": "Nous y sommes presque...",
-      "no_products_html": "Vous n'avez pas de produit dans votre collection Frontpage. Ce message apparaitra jusqu'à ce qu'un produit soit <a href=\"/admin/collections?tutorial=Frontpage\">ajouté à cette collection</a>.",
-      "add_product": "Ajouter un produit",
       "product_title": "Titre du produit",
-      "no_collections_html": "Vous n'avez pas de collection à afficher ici. <a href=\"/admin/custom_collections\">Ajoutez une ou plusieurs collections</a> pour compléter la page d'accueil par défaut.",
-      "add_collection": "Ajouter une collection",
       "collection_title": "Titre de la collection"
     }
   },

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} item",
         "other": "{{ count }} itens"
       }
-    },
-    "onboarding": {
-      "modal_title": "Esta página mostrará todos os produtos de sua loja",
-      "no_products_html": "Não há nenhum produto ainda, mas, quando você começar a adicioná-los, eles aparecerão aqui, independentemente se estiverem em uma coleção.",
-      "add_product": "Adicionar produto"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Coleções em destaque"
     },
     "onboarding": {
-      "modal_title": "Quase lá...",
-      "no_products_html": "Não há produtos na sua coleção \"Primeira Página\". Este espaço reservado aparecerá até que você <a href=\"/admin/collections?tutorial=Frontpage\">adicione um produto a esta coleção</a>.",
-      "add_product": "Adicionar um produto",
       "product_title": "Exemplo de título de produto",
-      "no_collections_html": "Você não tem coleções para exibir aqui. <a href=\"/admin/custom_collections\">Adicione algumas coleções</a> para acompanhar a \"Primeira Página\" padrão.",
-      "add_collection": "Adicionar uma coleção",
       "collection_title": "Exemplo de título de coleção"
     }
   },

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -100,11 +100,6 @@
         "one": "{{ count }} item",
         "other": "{{ count }} itens"
       }
-    },
-    "onboarding": {
-      "modal_title": "Esta página irá exibir todos os produtos da sua loja",
-      "no_products_html": "Ainda não há artigos, mas assim que começar a adicioná-los, eles vão surgir aqui, mesmo se não estiverem inseridos numa colecção.",
-      "add_product": "Adicionar Produto"
     }
   },
   "contact": {
@@ -225,12 +220,7 @@
       "featured_title": "Coleções em Destaque"
     },
     "onboarding": {
-      "modal_title": "Quase lá...",
-      "no_products_html": "Não tem produtos na sua Coleção Frontpage. Esta imagem de preenchimento será exibida até <a href=\"/admin/collections?tutorial=Frontpage\">adicionar um produto a esta coleção</a>.",
-      "add_product": "Adicionar um produto",
       "product_title": "Título do Produto Exemplo",
-      "no_collections_html": "Ainda não tem coleções para exibir aqui. <a href=\"/admin/custom_collections\">Adicione algumas coleções</a> para continuar com a Frontpage predefinida.",
-      "add_collection": "Adicionar uma coleção",
       "collection_title": "Título da Coleção Exemplo"
     }
   },

--- a/src/templates/collection.liquid
+++ b/src/templates/collection.liquid
@@ -78,43 +78,24 @@
 
     {% else %}
       {% if collection.handle == 'all' %}
-
-        {% unless onboardingLoaded %}
-          {{ 'theme-onboarding.css' | global_asset_url | stylesheet_tag }}
-          {%- assign onboardingLoaded = true -%}
-        {% endunless %}
-
-        <div class="helper-section">
-          <div class="helper-note">
-            <span class="helper-icon"></span>
-            <h3>{{ 'collections.onboarding.modal_title' | t }}</h3>
-            <p>{{ 'collections.onboarding.no_products_html' | t }}</p>
-            <p><a href="/admin/products/new" class="admin-btn-primary">{{ 'collections.onboarding.add_product' | t }}</a></p>
+        {%- assign collection_index = 1 -%}
+        {% for i in (1..8) %}
+          {% case i %}
+          {% when 7 %}
+          {%- assign collection_index = 1 -%}
+          {% when 8 %}
+          {%- assign collection_index = 2 -%}
+          {% endcase %}
+          <div>
+            <a href="/admin/products">
+              {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ collection_index }}.png{% endcapture %}
+              {{ imageUrl | img_tag }}
+            </a>
+            <p><a href="/admin/products">{{ 'homepage.onboarding.product_title' | t }}</a></p>
+            <p>$19.99</p>
           </div>
-
-          <div class="helper-content">
-            {%- assign collection_index = 1 -%}
-            {% for i in (1..8) %}
-              {% case i %}
-              {% when 7 %}
-              {%- assign collection_index = 1 -%}
-              {% when 8 %}
-              {%- assign collection_index = 2 -%}
-              {% endcase %}
-              <div>
-                <a href="/admin/products">
-                  {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ collection_index }}.png{% endcapture %}
-                  {{ imageUrl | img_tag }}
-                </a>
-                <p><a href="/admin/products">{{ 'homepage.onboarding.product_title' | t }}</a></p>
-                <p>$19.99</p>
-              </div>
-              {%- assign collection_index = collection_index | plus: 1 -%}
-            {% endfor %}
-          </div>
-        </div>
-
-
+          {%- assign collection_index = collection_index | plus: 1 -%}
+        {% endfor %}
       {% else %}
         <p>{{ 'collections.general.no_matches' | t }}</p>
       {% endif %}

--- a/src/templates/index.liquid
+++ b/src/templates/index.liquid
@@ -18,36 +18,18 @@
 {% endfor %}
 
 {% if shop.collections_count <= 1 %}
-  {% unless onboardingLoaded %}
-    {% comment %}
-      Only load onboarding styles if they have not already been loaded.
-    {% endcomment %}
-    {{ 'theme-onboarding.css' | global_asset_url | stylesheet_tag }}
-    {%- assign onboardingLoaded = true -%}
-  {% endunless %}
-  <div class="helper-section">
-    <div class="helper-note">
-      <span class="helper-icon"></span>
-      <h3>{{ 'homepage.onboarding.modal_title' | t }}</h3>
-      <p>{{ 'homepage.onboarding.no_collections_html' | t }}</p>
-      <p><a class="admin-btn-primary" href="/admin/custom_collections">{{ 'homepage.onboarding.add_collection' | t }}</a></p>
+  {% for i in (1..5) %}
+    <div>
+      <a href="#">
+        {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
+        {{ imageUrl | img_tag }}
+      </a>
+      <p>
+        <a href="#">{{ 'homepage.onboarding.collection_title' | t }}</a>
+      </p>
+      <p>{{ 'collections.general.items_with_count' | t: count: i }}</p>
     </div>
-
-    <div class="helper-content">
-      {% for i in (1..5) %}
-        <div>
-          <a href="#">
-            {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
-            {{ imageUrl | img_tag }}
-          </a>
-          <p>
-            <a href="#">{{ 'homepage.onboarding.collection_title' | t }}</a>
-          </p>
-          <p>{{ 'collections.general.items_with_count' | t: count: i }}</p>
-        </div>
-      {% endfor %}
-    </div>
-  </div>
+  {% endfor %}
 {% endif %}
 
 <h2>{{ 'homepage.sections.frontpage_title' | t }}</h2>
@@ -92,37 +74,17 @@
 {% else %}
   {% comment %}
     If collection is empty, show onboarding state
-    For onboarding new users to your theme, we add some default products and onboarding tutorials to help populate their store
   {% endcomment %}
-  {% unless onboardingLoaded %}
-    {% comment %}
-      Only load onboarding styles if they have not already been loaded.
-    {% endcomment %}
-    {{ 'theme-onboarding.css' | global_asset_url | stylesheet_tag }}
-    {%- assign onboardingLoaded = true -%}
-  {% endunless %}
-
-  <div class="helper-section">
-    <div class="helper-note">
-      <span class="helper-icon"></span>
-      <h3>{{ 'homepage.onboarding.modal_title' | t }}</h3>
-      <p>{{ 'homepage.onboarding.no_products_html' | t }}</p>
-      <p><a class="admin-btn-primary" href="/admin/collections?tutorial=Frontpage">{{ 'homepage.onboarding.add_product' | t }}</a></p>
+  {% for i in (1..5) %}
+    <div>
+      <a href="/admin/products">
+        {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
+        {{ imageUrl | img_tag }}
+      </a>
+      <p><a href="/admin/products">{{ 'homepage.onboarding.product_title' | t }}</a></p>
+      <p>$19.99</p>
     </div>
-
-    <div class="helper-content">
-      {% for i in (1..5) %}
-        <div>
-          <a href="/admin/products">
-            {% capture imageUrl %}//cdn.shopify.com/s/images/themes/product-{{ i }}.png{% endcapture %}
-            {{ imageUrl | img_tag }}
-          </a>
-          <p><a href="/admin/products">{{ 'homepage.onboarding.product_title' | t }}</a></p>
-          <p>$19.99</p>
-        </div>
-      {% endfor %}
-    </div>
-  </div>
+  {% endfor %}
 {% endfor %}
 
 {% if settings.home_page_content != blank %}


### PR DESCRIPTION
We're no longer going to have the hover over onboarding content. This PR removes it.

Waiting for tests to fail so I know exactly what strings to remove.

@Shopify/themes-fed for 👍 
