### PR TITLE
fixes reference to old JS file

### DIFF
--- a/src/scripts/theme.js
+++ b/src/scripts/theme.js
@@ -12,10 +12,9 @@ window.theme = window.theme || {};
 /*================ Sections ================*/
 // =require sections/product.js
 
-/*================ Sections ================*/
+/*================ Templates ================*/
 // =require templates/customers-addresses.js
 // =require templates/customers-login.js
-// =require templates/giftcard.js
 
 $(document).ready(function() {
   var sections = new slate.Sections();


### PR DESCRIPTION
@Shopify/themes-fed 

Found this happy little mistake

![](https://media.giphy.com/media/B5zU6avdXlkY0/giphy.gif)
