### PR TITLE
Add featured product as default section

### DIFF
--- a/src/config/settings_data.json
+++ b/src/config/settings_data.json
@@ -27,11 +27,15 @@
           "settings": {
             "collection": "frontpage"
           }
+        },
+        "featured-product": {
+          "type": "featured-product"
         }
       },
       "content_for_index": [
         "collection-list",
-        "featured-collection"
+        "featured-collection",
+        "featured-product"
       ]
     }
   }


### PR DESCRIPTION
Default sections (in order)
- collection list
- featured collection (list of products from a selected collection, defaults to "frontpage" if it has products)
- featured product (cannot set a default yet)

Demo http://carson-blocks.myshopify.com/?preview_theme_id=132796035

@Shopify/themes-fed 

Fixes https://github.com/Shopify/themes-dev-workflow/issues/731
