### PR TITLE
Force icons to inherit currentColor

### DIFF
--- a/src/styles/global/icons.scss
+++ b/src/styles/global/icons.scss
@@ -4,6 +4,7 @@
   width: 20px;
   height: 20px;
   vertical-align: middle;
+  fill: currentColor;
 
   .no-svg & {
     display: none;

--- a/src/styles/modules/password-template.scss
+++ b/src/styles/modules/password-template.scss
@@ -3,7 +3,6 @@
   width: 1.5 * $font-size-base * 120 / 35;
   height: 1.5 * $font-size-base;
   vertical-align: middle;
-  fill: currentColor;
 }
 
 .icon-lock {


### PR DESCRIPTION
Same update as Debut (https://github.com/Shopify/shopify-themes/pull/4167/files) so that `.icon` classes inherit the color of their parent, be it text or links. This will prevent us from having to set `fill: #hex` or `fill: currentColor` on each instance of an icon in the theme while keeping its ability for an override.

Fixes https://github.com/Shopify/slate/issues/37

@Shopify/themes-fed 