### PR TITLE
Deploy fixes and node_modules

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,8 +1,11 @@
+machine:
+  node:
+    version: 6.2.2
 deploy:
   override:
-    - npm install -g @shopify/slate --no-progress
     - npm install --no-progress
-    - slate zip
+    - npm install @shopify/slate --no-progress
+    - ./node_modules/.bin/slate zip
     - ejson decrypt -o secrets.json secrets.ejson
     - node scripts/build-src
     - node scripts/deploy


### PR DESCRIPTION
@cshold @m-ux @macdonaldr93 

- fixes issue with deploy caused by node v4.x on shipit 
- updates deploy now that `slate-tools` tasks are imported by `slate-cli`
- ~~includes our `node_modules` and `package.json` on our S3 deploys to save install time for `slate theme`~~