### PR TITLE
Fix formatting in js-examples

### DIFF
--- a/docs/js-examples/index.md
+++ b/docs/js-examples/index.md
@@ -86,6 +86,7 @@ window.theme.moneyFormat: {% raw %}{{ shop.money_format | json }}{% endraw %};
 | `format`        | string          | shop.money_format setting |
 
 In this example, `shop.money_format` is {% raw %}`${{amount}}`{% endraw %} so 1999 cents would be formatted as $19.99.
+
 ```
 var itemPrice = 1999; // cents
 slate.Currency.formatMoney(itemPrice, theme.moneyFormat);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/991693/20727885/2a1151cc-b649-11e6-9119-b7308044d768.png)

@cshold 