### PR TITLE
add product variants link to JS examples sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ deploy.log
 config.yml
 secrets.json
 .jekyll-metadata
+.ruby-version

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -78,6 +78,9 @@
       <li>
         <a href="{{ '/js-examples/#image-helpers' | prepend: site.baseurl }}" class="docs-sub-nav__link">Image helpers</a>
       </li>
+      <li>
+        <a href="{{ '/js-examples/#product-variants' | prepend: site.baseurl }}" class="docs-sub-nav__link">Product variants</a>
+      </li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
Anchor link for `h2` element missing from sidebar.