### PR TITLE
remove hardcoded strings

### DIFF
--- a/src/snippets/pagination.liquid
+++ b/src/snippets/pagination.liquid
@@ -1,3 +1,3 @@
 <div class="pagination">
-  {{ paginate | default_pagination: next: 'Next', previous: 'Previous' }}
+  {{ paginate | default_pagination }}
 </div>


### PR DESCRIPTION
In the event we can't get Circle Ci to play nice here: https://github.com/Shopify/slate/pull/74

**Update** Circle CI _did not_ play nice, so I'm going with this one.

---

Removing the hardcoded English strings.  If no options for `next` or `previous` are provided, Shopify [provides fallbacks](https://github.com/Shopify/shopify/blob/90b64020ec2f69ee1e02e2d7ae3888660e04055a/app/liquid/filters/pagination_filter.rb).

<details><summary>Example: Store in French</summary>

![http://take.ms/O28jX](http://take.ms/O28jX)

</details> 
<br>

This PR loses the demonstration that you can use `next` and `previous`, but I feel it's more important that we discourage hardcoded strings.