### PR TITLE
indentation on if-statements fix

### DIFF
--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -15,21 +15,21 @@
   <header role="banner">
     {% if template == 'index' %}
       <h1 itemscope itemtype="http://schema.org/Organization">
-        {% else %}
-        <div class="h1" itemscope itemtype="http://schema.org/Organization">
+    {% else %}
+      <div class="h1" itemscope itemtype="http://schema.org/Organization">
+    {% endif %}
+        <a href="/" itemprop="url" class="site-logo{% if section.settings.logo != blank %} site-header__logo-image{% endif %}">
+          {% if section.settings.logo != blank %}
+            {% capture image_size %}{{ section.settings.logo_max_width }}x{% endcapture %}
+            <img src="{{ section.settings.logo | img_url: image_size }}"
+                 srcset="{{ section.settings.logo | img_url: image_size }} 1x, {{ section.settings.logo | img_url: image_size, scale: 2 }} 2x"
+                 alt="{{ section.settings.logo.alt | default: shop.name }}"
+                 itemprop="logo">
+          {% else %}
+            {{ shop.name }}
           {% endif %}
-          <a href="/" itemprop="url" class="site-logo{% if section.settings.logo != blank %} site-header__logo-image{% endif %}">
-            {% if section.settings.logo != blank %}
-              {% capture image_size %}{{ section.settings.logo_max_width }}x{% endcapture %}
-              <img src="{{ section.settings.logo | img_url: image_size }}"
-                   srcset="{{ section.settings.logo | img_url: image_size }} 1x, {{ section.settings.logo | img_url: image_size, scale: 2 }} 2x"
-                   alt="{{ section.settings.logo.alt | default: shop.name }}"
-                   itemprop="logo">
-            {% else %}
-              {{ shop.name }}
-            {% endif %}
-          </a>
-          {% if template == 'index' %}
+        </a>
+    {% if template == 'index' %}
       </h1>
     {% else %}
       </div>


### PR DESCRIPTION
The indentation on the if-statements makes it look like some items are nested within one another when they really aren't.  [Screenshot](https://screenshot.click/header.liquid__codedatsun-liquid-demodatsun-sections_2016-12-25_21-31-01.png).

Minor, but it was bugging me.