### PR TITLE
Fix instance removal

### DIFF
--- a/src/scripts/slate/sections.js
+++ b/src/scripts/slate/sections.js
@@ -40,13 +40,17 @@ slate.Sections.prototype = $.extend({}, slate.Sections.prototype, {
   },
 
   _onSectionUnload: function(evt) {
-    this.instances = slate.utils.removeInstance(this.instances, 'id', evt.detail.sectionId);
+    var instance = slate.utils.findInstance(this.instances, 'id', evt.detail.sectionId);
 
-    this.instances.forEach(function(instance) {
-      if (typeof instance.onUnload === 'function') {
-        instance.onUnload(evt);
-      }
-    });
+    if (!instance) {
+      return;
+    }
+
+    if (typeof instance.onUnload === 'function') {
+      instance.onUnload(evt);
+    }
+
+    this.instances = slate.utils.removeInstance(this.instances, 'id', evt.detail.sectionId);
   },
 
   _onSelect: function(evt) {


### PR DESCRIPTION
My [last PR](https://github.com/Shopify/slate/pull/78) wasn't quite right. When unloading a section we should fire the `onUnload` function of that instance if it exists *and then* remove it from `this.instances`.

Before this PR, the `onUnload` function of every remaining section would fire instead of the only one we really want.