### PR TITLE
Add documentation for migrate command

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -9,6 +9,7 @@ layout: default
 | Command | Usage |
 | :------ | :---- |
 | [theme](#theme) | `slate theme [name]` |
+| [migrate](#migrate) | `slate migrate` |
 | [help](#help) | `slate -h` |
 | [version](#version) | `slate -v` |
 
@@ -19,6 +20,15 @@ slate theme [name]
 ```
 
 Generate a new blank theme. The `name` argument is required for the new theme directory.
+
+### migrate
+```
+slate migrate
+```
+
+Converts an existing theme to work with Slate. Run this command from your project root to install dependencies and restructure your theme files into a `src/` directory. Empty `icons/`, `styles/`, and `scripts/` folders will also be created.
+
+Create `config.yml` in your root using [this sample file](https://github.com/Shopify/slate/blob/master/config-sample.yml), then use [theme commands](#theme-commands) to start developing.
 
 ### help
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,12 @@ Slate allows you to sync local files with your live shop, deploy to multiple env
 > [Node](https://nodejs.org/en/) 4+ is supported, but 6+ is recommended to fully benefit from Slate. If you want the template files without the build tools, [get the latest zip here](https://sdks.shopifycdn.com/slate/latest/slate-src.zip).
 
 1. Install Slate with `npm install -g @shopify/slate`.
-2. Create a new theme with `slate theme theme-name`, where `theme-name` will be a newly created folder.
+2. Create a new theme with `slate theme theme-name`, where `theme-name` will be a newly created folder. If you already have a theme locally, you can use the `slate migrate` command and [follow these steps](/slate/commands/#migrate) instead.
 3. Create a private app on your development store(s).
   * Not sure how to create a private app? [Learn how here](https://help.shopify.com/api/guides/api-credentials#get-credentials-through-the-shopify-admin).
   * Set the "Theme templates and theme assets" permission to "Read and write".
   <img src="{{ "/assets/images/app-permission.jpg" | prepend: site.baseurl }}" alt="Private app permission requirements" class="demo-image demo-image--app">
-4. Rename `config-sample.yml` to `config.yml` and add your private app credentials:
+4. Rename `config-sample.yml` to `config.yml` and add your private app credentials.
   * **store:** the shopify-specifc URL for this store/environment (ie. my-store.myshopify.com)
   * **theme_id:** the unique id for the theme you want to write to when deploying to this store. You can find this information in the URL of the theme's online editor at Shopify [admin/themes](https://shopify.com/admin/themes). Alternatively, you can use `"live"` for the published theme.
   <img src="{{ "/assets/images/theme-id.png" | prepend: site.baseurl }}" alt="Private app credentials" class="demo-image demo-image--app">
@@ -30,6 +30,7 @@ Slate allows you to sync local files with your live shop, deploy to multiple env
 
 ### Global
 * `slate theme [name]` - Generate a new blank theme
+* `slate migrate` - Convert an existing theme to work with Slate
 * `slate -h` - Options available in your current directory (differs if not in a theme)
 * `slate -v` - See your currently installed version of Slate and dependencies
 


### PR DESCRIPTION
Adds documentation for https://github.com/Shopify/slate-cli/pull/108

cc @Shopify/themes-fed 