### PR TITLE
Add product position

### DIFF
--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -52,7 +52,7 @@
             <select
               id="SingleOptionSelector-{{ section.id }}-{{ forloop.index0 }}"
               data-single-option-selector
-              data-index="option{{ forloop.index }}">
+              data-index="option{{ option.position }}">
               {% for value in option.values %}
                 <option
                   value="{{ value | escape }}"

--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -40,7 +40,7 @@
     <link itemprop="availability" href="http://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}">
 
     <form action="/cart/add" method="post" enctype="multipart/form-data">
-      {% unless product.options.size == 1 and product.variants[0].title == 'Default Title' %}
+      {% unless product.variants.size == 1 and product.options.size == 1 and product.options.first == 'Title' and product.variants.first.title == 'Default Title' %}
         {% for option in product.options_with_values %}
           <div class="selector-wrapper js">
             <label

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -32,7 +32,7 @@
     <link itemprop="availability" href="http://schema.org/{% if current_variant.available %}InStock{% else %}OutOfStock{% endif %}">
 
     <form action="/cart/add" method="post" enctype="multipart/form-data">
-      {% unless product.options.size == 1 and product.variants[0].title == 'Default Title' %}
+      {% unless product.variants.size == 1 and product.options.size == 1 and product.options.first == 'Title' and product.variants.first.title == 'Default Title' %}
         {% for option in product.options_with_values %}
           <div class="selector-wrapper js">
             <label

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -44,7 +44,7 @@
             <select
               id="SingleOptionSelector-{{ forloop.index0 }}"
               data-single-option-selector
-              data-index="option{{ forloop.index }}">
+              data-index="option{{ option.position }}">
               {% for value in option.values %}
                 <option
                   value="{{ value | escape }}"


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Use `product.position` instead of `forloop.index` as it is more accurate in what the JS is trying to accomplish in variant selection.  Now the JS isn't tied to the product options being listed in the same order as the admin.

Documentation for public site PR has already been made here: https://github.com/Shopify/documentation/pull/9525

Also, I've put in the stronger check for default variant that we've implemented in our other themes.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

