### PR TITLE
Compare at price logic

### DIFF
--- a/src/scripts/sections/product.js
+++ b/src/scripts/sections/product.js
@@ -12,6 +12,7 @@ theme.Product = (function() {
     addToCart: '[data-add-to-cart]',
     addToCartText: '[data-add-to-cart-text]',
     comparePrice: '[data-compare-price]',
+    comparePriceText: '[data-compare-text]',
     originalSelectorId: '[data-product-select]',
     priceWrapper: '[data-price-wrapper]',
     productFeaturedImage: '[data-product-featured-image]',
@@ -103,16 +104,18 @@ theme.Product = (function() {
      */
     updateProductPrices: function(evt) {
       var variant = evt.variant;
+      var $comparePrice = $(selectors.comparePrice, this.$container);
+      var $compareEls = $comparePrice.add(selectors.comparePriceText, this.$container);
 
       $(selectors.productPrice, this.$container)
         .html(slate.Currency.formatMoney(variant.price, theme.moneyFormat));
 
       if (variant.compare_at_price > variant.price) {
-        $(selectors.comparePrice, this.$container)
-          .html(slate.Currency.formatMoney(variant.compare_at_price, theme.moneyFormat))
-          .removeClass('hide');
+        $comparePrice.html(slate.Currency.formatMoney(variant.compare_at_price, theme.moneyFormat));
+        $compareEls.removeClass('hide');
       } else {
-        $(selectors.comparePrice, this.$container).addClass('hide');
+        $comparePrice.html('');
+        $compareEls.addClass('hide');
       }
     },
 

--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -1,4 +1,5 @@
 {%- assign product = all_products[section.settings.product] -%}
+{%- assign current_variant = product.selected_or_first_available_variant -%}
 
 {% if product.empty? %}
   {%- assign section_onboarding = true -%}
@@ -81,13 +82,15 @@
 
       <div data-price-wrapper>
         <span data-product-price>
-          {{ product.price | default: '1999' | money }}
+          {{ current_variant.price | default: '1999' | money }}
         </span>
 
         {% if product.compare_at_price_max > product.price %}
-          <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
+          <span class="visually-hidden" data-compare-text>{{ 'products.product.regular_price' | t }}</span>
           <s data-compare-price>
-            {{ product.compare_at_price | money }}
+            {% if current_variant.compare_at_price > current_variant.price %}
+              {{ current_variant.compare_at_price | money }}
+            {% endif %}
           </s>
         {% endif %}
       </div>

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -76,10 +76,12 @@
           {{ current_variant.price | money }}
         </span>
 
-        {% if current_variant.compare_at_price_max > current_variant.price %}
+        {% if product.compare_at_price_max > product.price %}
           <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
           <s data-compare-price>
-            {{ current_variant.compare_at_price | money }}
+            {% if current_variant.compare_at_price > current_variant.price %}
+              {{ current_variant.compare_at_price | money }}
+            {% endif %}
           </s>
         {% endif %}
       </div>

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -77,7 +77,7 @@
         </span>
 
         {% if product.compare_at_price_max > product.price %}
-          <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
+          <span class="visually-hidden" data-compare-text>{{ 'products.product.regular_price' | t }}</span>
           <s data-compare-price>
             {% if current_variant.compare_at_price > current_variant.price %}
               {{ current_variant.compare_at_price | money }}


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/96

* Always render markup for compare at price, so JS can update it.
* On featured product page, use `current_variant` information so the initial prices displayed reflect the option selectors.

New stuff:
The changes in `product.js` have to do with how we are handling compare_at information when the variant is on sale.  We are always leaving the "compare_at" text on screen for screenreaders, even when we were hiding the sale price. Now it hides that text if the variant isn't on sale.

I also update the strikethrough price when the variant isn't on sale.  It was already being hidden with the `hide` class, but it just felt odd to leave a strikethrough price in the markup if we had no intention of using it.

/cc @Shopify/themes-fed 

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

