### PR TITLE
Add defaultTo function

### DIFF
--- a/src/scripts/slate/currency.js
+++ b/src/scripts/slate/currency.js
@@ -27,9 +27,9 @@ slate.Currency = (function() {
     var formatString = (format || moneyFormat);
 
     function formatWithDelimiters(number, precision, thousands, decimal) {
-      precision = precision || 2;
-      thousands = thousands || ',';
-      decimal = decimal || '.';
+      precision = slate.utils.defaultTo(precision, 2);
+      thousands = slate.utils.defaultTo(thousands, ',');
+      decimal = slate.utils.defaultTo(decimal, '.');
 
       if (isNaN(number) || number == null) {
         return 0;

--- a/src/scripts/slate/utils.js
+++ b/src/scripts/slate/utils.js
@@ -63,4 +63,19 @@ slate.utils = {
     }
     return result;
   }
+
+  /**
+   * _.defaultTo from lodash
+   * Checks `value` to determine whether a default value should be returned in
+   * its place. The `defaultValue` is returned if `value` is `NaN`, `null`,
+   * or `undefined`.
+   * Source: https://github.com/lodash/lodash/blob/master/defaultTo.js
+   *
+   * @param {*} value - Value to check
+   * @param {*} defaultValue - Default value
+   * @returns {*} - Returns the resolved value
+   */
+  function defaultTo(value, defaultValue) {
+    return (value == null || value !== value) ? defaultValue : value
+  }  
 };

--- a/src/scripts/slate/utils.js
+++ b/src/scripts/slate/utils.js
@@ -62,7 +62,7 @@ slate.utils = {
       }
     }
     return result;
-  }
+  },
 
   /**
    * _.defaultTo from lodash
@@ -75,7 +75,7 @@ slate.utils = {
    * @param {*} defaultValue - Default value
    * @returns {*} - Returns the resolved value
    */
-  function defaultTo(value, defaultValue) {
+  defaultTo: function(value, defaultValue) {
     return (value == null || value !== value) ? defaultValue : value
-  }  
+  }
 };


### PR DESCRIPTION
### What are you trying to accomplish with this PR?  

Fixes #113 
Following the lead of PR https://github.com/Shopify/slate/pull/78, Lodash's `_.defaultTo` function was added to `slate.utils`

Now the `formatWithDelimiters` function inside `slate.Currency` can correctly apply a default value of `2` if the `precision` argument equals `0`—as well as any other place where a default variable needs to be set.

https://github.com/lodash/lodash/blob/master/defaultTo.js

```js
slate.utils.defaultTo(1, 10)
// => 1

slate.utils.defaultTo(0, 10)
// => 0

slate.utils.defaultTo(undefined, 10)
// => 10
```

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

