### PR TITLE
Fix broken license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ All developers who wish to contribute through code or issues, take a look at the
 
 ## License
 
-MIT, see [LICENSE.md](http://github.com/Shopify/slate/blob/master/LICENSE.md) for details.
+MIT, see [LICENSE](http://github.com/Shopify/slate/blob/master/LICENSE) for details.
 
 <img src="https://cdn.shopify.com/shopify-marketing_assets/builds/19.0.0/shopify-full-color-black.svg" width="200" />


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fix the readme license link, it was 404'ing previously.

### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [x] I have bumped the `package.json` version in a separate PR, if applicable.

@NathanPJF 