### PR TITLE
Docs theme scaffolding sass, js, and locales

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -30,7 +30,7 @@
         <a href="{{ '/theme-scaffold/#sections' | prepend: site.baseurl }}" class="docs-sub-nav__link">Sections</a>
       </li>
       <li>
-        <a href="{{ '/theme-scaffold/#sass-scaffolding-and-helpers' | prepend: site.baseurl }}" class="docs-sub-nav__link">Sass scaffolding and helpers</a>
+        <a href="{{ '/theme-scaffold/#sass-helpers' | prepend: site.baseurl }}" class="docs-sub-nav__link">Sass helpers</a>
       </li>
       <li>
         <a href="{{ '/theme-scaffold/#javascript-helpers' | prepend: site.baseurl }}" class="docs-sub-nav__link">JavaScript helpers</a>

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -36,7 +36,7 @@
         <a href="{{ '/theme-scaffold/#javascript-helpers' | prepend: site.baseurl }}" class="docs-sub-nav__link">JavaScript helpers</a>
       </li>
       <li>
-        <a href="{{ '/theme-scaffold/#i18n-strings' | prepend: site.baseurl }}" class="docs-sub-nav__link">i18n strings</a>
+        <a href="{{ '/theme-scaffold/#translation-keys' | prepend: site.baseurl }}" class="docs-sub-nav__link">Translation keys</a>
       </li>
     </ul>
   </li>

--- a/docs/theme-scaffold/index.md
+++ b/docs/theme-scaffold/index.md
@@ -72,7 +72,7 @@ sections/
 ## Sass helpers
 
 <blockquote>
-Slate does not compile Sass to CSS.  Slate uploads Scss files to your theme's <code>assets</code> directory and compilation is done by Shopify.  Shopify is using a forked version of Sass v3.2 which does not support importing partial Sass files with the <code>@import</code> directive.
+Slate does not compile Sass to CSS.  Slate uploads <code>.scss</code> files to your theme's <code>/assets</code> directory and compilation is done by Shopify.  Shopify is using a forked version of Sass v3.2 which does not support importing partial Sass files with the <code>@import</code> directive.
 </blockquote>
 
 **Slate is not a CSS framework.** Instead it sets you up to start styling your way quickly with a reset and some helper scaffolding. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `import` statement in `theme.scss` to `@import url('new-folder/style.scss')`.

--- a/docs/theme-scaffold/index.md
+++ b/docs/theme-scaffold/index.md
@@ -69,7 +69,7 @@ sections/
   - featured-product
 ```
 
-## Sass scaffolding and helpers
+## Sass helpers
 
 **Slate is not a CSS framework.** Instead it sets you up to start styling your way quickly with a reset and some helper scaffolding. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `import` statement in `theme.scss` to `@import url('new-folder/style.scss')`.
 
@@ -81,6 +81,8 @@ styles/
   tools/
   vendor/
 ```
+
+
 
 ### Normalize and reset
 
@@ -135,6 +137,16 @@ scripts/
 - Helpers for handling images in JS, including getting size based on URL and preloading sets of images. [Examples]({{ '/js-examples/#image-helpers' | prepend: site.baseurl }})
 - Listen for product variant option changes and setup scaffolding for handling result. [Example]({{ '/js-examples/#product-variants' | prepend: site.baseurl }})
 
-## i18n strings
+## Translation keys
 
-i18n is shorthand for internationalization. Slate ships with six languages — English, French (Canadian), Spanish, German, and two dialects of Portuguese (Brazilian and European). These strings can be found in the `locales` folder. [Learn more about translating your themes here](https://help.shopify.com/manual/sell-online/online-store/translate-theme).
+Slate ships with six languages — English, French (Canadian), Spanish, German, and two dialects of Portuguese (Brazilian and European).  Translation keys for these languages can be found in the `locales` folder.  In your theme files, translated strings can be retrieved with the Liquid translation filter `t`.
+
+{% raw %}
+```
+{{ 'products.product.add_to_cart' | t }}
+```
+{% endraw %}
+
+You can learn more about using [translation keys and strings here](https://help.shopify.com/themes/development/internationalizing/translation-filter).
+
+These translation keys allow merchants to control their store's language settings from the admin.  Merchants can set the language of their storefront as well as change the value of individual translation keys. You can [learn more about translating your storefront here](https://help.shopify.com/manual/sell-online/online-store/translate-theme).

--- a/docs/theme-scaffold/index.md
+++ b/docs/theme-scaffold/index.md
@@ -122,7 +122,7 @@ A few helpful Sass mixins are included in Slate to make responsive, cross-browse
 
 ## JavaScript helpers
 
-Slate provides a number of helper scripts and vendor scripts. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `require` statement in `theme.js` to `// =require new-folder/script.js`.
+Slate provides a number of helper scripts and vendor scripts. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `require` statement in `theme.js` to `// =require new-folder/script.js`.  
 
 ```
 scripts/
@@ -131,6 +131,10 @@ scripts/
   templates/
   vendor/
 ```
+
+<blockquote>
+More information about the <code>require</code> directive can be found in the <a href="https://www.npmjs.com/package/gulp-include">NPM documentation</a> for <code>gulp-include</code>.
+</blockquote>
 
 ### Slate scripts
 
@@ -145,7 +149,7 @@ Slate provides helper scripts to promote accessibility and make working with the
 
 ### Vendor scripts
 
-Slate projects include a `vendor` folder where theme developers are encouraged to place third-party libraries.  Versions of jQuery and Modernizer are included in a new project, but you are welcome to change these as you see fit.  Be sure to update the `require` statement in `vendor.js` as you add and remove libraries.
+Slate projects include a `vendor` folder where theme developers are encouraged to place third-party libraries.  Versions of jQuery and [Modernizr](https://modernizr.com/) are included in a new project, but you are welcome to change these as you see fit.  Be sure to update the `require` statement in `vendor.js` as you add and remove libraries.
 
 ## Translation keys
 
@@ -157,6 +161,6 @@ Slate ships with six languages — English, French (Canadian), Spanish, German, 
 ```
 {% endraw %}
 
-You can learn more about using [translation keys and strings here](https://help.shopify.com/themes/development/internationalizing/translation-filter).
+You can learn more about using [translation keys and strings in our theme development documentation](https://help.shopify.com/themes/development/internationalizing/translation-filter).
 
-These translation keys allow merchants to control their store's language settings from the admin.  Merchants can set the language of their storefront as well as change the value of individual translation keys. You can [learn more about translating your storefront here](https://help.shopify.com/manual/sell-online/online-store/translate-theme).
+These translation keys allow merchants to control their store's language settings from the admin.  Merchants can set the language of their storefront as well as change the value of individual translation keys. You can learn more about [translating your storefront in our theme documentation ](https://help.shopify.com/manual/sell-online/online-store/translate-theme).

--- a/docs/theme-scaffold/index.md
+++ b/docs/theme-scaffold/index.md
@@ -122,7 +122,7 @@ A few helpful Sass mixins are included in Slate to make responsive, cross-browse
 
 ## JavaScript helpers
 
-Slate provides helper scripts to promote accessibility and make working with theme images, currencies, and product variants easier. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `require` statement in `theme.js` to `// =require new-folder/script.js`.
+Slate provides a number of helper scripts and vendor scripts. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `require` statement in `theme.js` to `// =require new-folder/script.js`.
 
 ```
 scripts/
@@ -132,12 +132,20 @@ scripts/
   vendor/
 ```
 
+### Slate scripts
+
+Slate provides helper scripts to promote accessibility and make working with theme images, currencies, and product variants easier.  See [JS examples]({{ '/js-examples/' | prepend: site.baseurl }}) for more details on how to use these scripts.
+
 - Accessibility helpers. [Example]({{ '/js-examples/#trap-focus' | prepend: site.baseurl }}). [Source](https://github.com/Shopify/slate/blob/master/src/scripts/slate/a11y.js).
 - Force tables and videos to be responsive. [Example]({{ '/js-examples/#responsive-tables-and-videos' | prepend: site.baseurl }})
 - Easy handling of theme editor events (load, select, deselect or sections and their content) (need demo/example of this)
 - Format currency in JS the same as Liquid allows. [Example]({{ '/js-examples/#format-currency' | prepend: site.baseurl }})
 - Helpers for handling images in JS, including getting size based on URL and preloading sets of images. [Examples]({{ '/js-examples/#image-helpers' | prepend: site.baseurl }})
 - Listen for product variant option changes and setup scaffolding for handling result. [Example]({{ '/js-examples/#product-variants' | prepend: site.baseurl }})
+
+### Vendor scripts
+
+Slate projects include a `vendor` folder where theme developers are encouraged to place third-party libraries.  Versions of jQuery and Modernizer are included in a new project, but you are welcome to change these as you see fit.  Be sure to update the `require` statement in `vendor.js` as you add and remove libraries.
 
 ## Translation keys
 

--- a/docs/theme-scaffold/index.md
+++ b/docs/theme-scaffold/index.md
@@ -71,6 +71,10 @@ sections/
 
 ## Sass helpers
 
+<blockquote>
+Slate does not compile Sass to CSS.  Slate uploads Scss files to your theme's <code>assets</code> directory and compilation is done by Shopify.  Shopify is using a forked version of Sass v3.2 which does not support importing partial Sass files with the <code>@import</code> directive.
+</blockquote>
+
 **Slate is not a CSS framework.** Instead it sets you up to start styling your way quickly with a reset and some helper scaffolding. The base folder names can be changed to suit your workflow. If changing or adding folders, make sure to update the `import` statement in `theme.scss` to `@import url('new-folder/style.scss')`.
 
 ```
@@ -81,8 +85,6 @@ styles/
   tools/
   vendor/
 ```
-
-
 
 ### Normalize and reset
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

* Provide more information about how Sass is handled by both Slate and Shopify
  * Been getting questions about what version of Sass Shopify uses or why Sass is failing to compile.
* Give more helpful links about translation keys and info on how to use them.
* Flesh out the JavaScript section a bit more.


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

