### PR TITLE
add to docs and section-js

### DIFF
--- a/docs/js-examples/index.md
+++ b/docs/js-examples/index.md
@@ -172,7 +172,7 @@ The Slate theme has two script files to manage the display of product variants:
 
 ### variant.js
 
-Slate separates product variant options into multiple `<select>` elements.  When a variant changes, `variant.js` updates the *master select*.  The master select is the default `<select>` element that contains all variant IDs needed to properly submit the form. 
+Slate separates product variant options into multiple `<select>` elements.  When a variant changes, `variant.js` updates the *master select*.  The master select is the default `<select>` element that contains all variant IDs needed to properly submit the form.
 
 Slate's `variant.js` also triggers a number of custom events to handle various state changes:
 
@@ -201,6 +201,7 @@ Slate comes with a `section.js` file to help Sections communicate with Shopify's
 | `onUnload()`        | A section has been deleted or is being re-rendered. |
 | `onSelect()`        | User has selected the section in the editor's sidebar. |
 | `onDeselect()`          | User has deselected the section in the editor's sidebar. |
+| `onReorder()`          | User has changed the section's order in the editor's sidebar. |
 | `onBlockSelect()`        | User has selected the block in the editor's sidebar. |
 | `onBlockDeselect()`        | User has deselected the block in the editor's sidebar. |
 
@@ -238,7 +239,7 @@ Slate follows a convention of wrapping the content of a Section file in an eleme
 ```
 {% endraw %}
 
-In the `theme.js` file, you must import the Section specific JavaScript with the `// =require` helper, [more information here](https://www.npmjs.com/package/gulp-include), as it will contain your `constructor`. 
+In the `theme.js` file, you must import the Section specific JavaScript with the `// =require` helper, [more information here](https://www.npmjs.com/package/gulp-include), as it will contain your `constructor`.
 
 ```
 // =require sections/product.js
@@ -248,4 +249,3 @@ $(document).ready(function() {
   sections.register('product', theme.Product);
 });
 ```
-

--- a/src/scripts/slate/sections.js
+++ b/src/scripts/slate/sections.js
@@ -7,6 +7,7 @@ slate.Sections = function Sections() {
     .on('shopify:section:unload', this._onSectionUnload.bind(this))
     .on('shopify:section:select', this._onSelect.bind(this))
     .on('shopify:section:deselect', this._onDeselect.bind(this))
+    .on('shopify:section:reorder', this._onReorder.bind(this))
     .on('shopify:block:select', this._onBlockSelect.bind(this))
     .on('shopify:block:deselect', this._onBlockDeselect.bind(this));
 };
@@ -66,6 +67,14 @@ slate.Sections.prototype = $.extend({}, slate.Sections.prototype, {
 
     if (instance && typeof instance.onDeselect === 'function') {
       instance.onDeselect(evt);
+    }
+  },
+
+  _onReorder: function(evt) {
+    var instance = slate.utils.findInstance(this.instances, 'id', evt.detail.sectionId);
+
+    if (instance && typeof instance.onReorder === 'function') {
+      instance.onReorder(evt);
     }
   },
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

* Add a `onReorder` method to registered sections.
* Document this new method.

Public docs for `shopify:section:reorder`: https://help.shopify.com/themes/development/theme-editor/sections#theme-editor-javascript-api


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

