### PR TITLE
Change media mixin to media-query

### DIFF
--- a/docs/css-examples/index.md
+++ b/docs/css-examples/index.md
@@ -34,7 +34,7 @@ Pass a media query name (above) to the media query mixin to generate media queri
 Define an element's background to pink above our large breakpoint value.
 
 ```
-@include media($medium-up) {
+@include media-query($medium-up) {
   .foo {
     background: pink;
   }
@@ -56,7 +56,7 @@ Define an element's background to blue, unless between the medium and large brea
 .foo {
   background: blue;
 
-  @include media($medium) {
+  @include media-query($medium) {
     background: pink;
   }
 }


### PR DESCRIPTION
Possible typo in documentation. Couldn't follow example until I changed to ```@include media-query(...)```

```@mixin media-query($media-query) { ... }``` in src/styles/tools/mixins.scss

### What are you trying to accomplish with this PR?

*Please provide a link to the associated GitHub issue.*
Cannot find an existing open issue for this.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

