### PR TITLE
Add test command documentation

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -70,7 +70,7 @@ Compile theme files and assets into a Shopify theme, found in the `dist` folder.
 slate test
 ```
 
-Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translations tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
+Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translation tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
 
 ### zip
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -53,6 +53,7 @@ Slate's source theme files are in the root `src` folder. These are the files you
 | Command | Usage |
 | :------ | :---- |
 | [build](#build) | `slate build` |
+| [test](#test) | `slate test` |
 | [zip](#zip) | `slate zip` |
 
 ### build
@@ -62,6 +63,14 @@ slate build
 ```
 
 Compile theme files and assets into a Shopify theme, found in the `dist` folder. No files will be uploaded to your shop.
+
+### test
+
+```
+slate test
+```
+
+Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translations tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
 
 ### zip
 


### PR DESCRIPTION
Adds `slate test` command documentation to `/docs`. Similar PR for Slate CLI can be found [here](https://github.com/Shopify/slate-cli/pull/120) and the `slate test` command PR can be found [here](https://github.com/Shopify/slate-tools/pull/55).

### Checklist
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.