### PR TITLE
Update for accessible payment icons

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} auf {{ platform }}",
-      "copyright": "Urheberrecht"
+      "copyright": "Urheberrecht",
+      "payment_methods": "Akzeptierte Zahlungsarten"
     }
   },
   "products": {

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} on {{ platform }}",
-      "copyright": "Copyright"
+      "copyright": "Copyright",
+      "payment_methods": "Payment methods accepted"
     }
   },
   "products": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} en {{ platform }}",
-      "copyright": "Derechos de autor"
+      "copyright": "Derechos de autor",
+      "payment_methods": "Medios de pago aceptados"
     }
   },
   "products": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} sur {{ platform }}",
-      "copyright": "Droit d'auteur"
+      "copyright": "Droit d'auteur",
+      "payment_methods": "Méthodes de paiement acceptées"
     }
   },
   "products": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} em {{ platform }}",
-      "copyright": "Direitos autorais"
+      "copyright": "Direitos autorais",
+      "payment_methods": "Métodos de pagamento aceitos"
     }
   },
   "products": {

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -235,7 +235,8 @@
     },
     "footer": {
       "social_platform": "{{ name }} na {{ plataform }}",
-      "copyright": "Direitos autorais"
+      "copyright": "Direitos autorais",
+      "payment_methods": "Métodos de pagamento aceites"
     }
   },
   "products": {

--- a/src/sections/footer.liquid
+++ b/src/sections/footer.liquid
@@ -23,6 +23,7 @@
     {% unless shop.enabled_payment_types == empty %}
       {%- assign payment_icons_available = 'amazon_payments,american_express,apple_pay,bitcoin,cirrus,dankort,diners_club,discover,dogecoin,dwolla,forbrugsforeningen,interac,jcb,litecoin,maestro,master,paypal,visa' | split: ',' -%}
 
+      <span class="visually-hidden">{{ 'layout.footer.payment_methods' | t }}</span>
       <ul class="payment-icons">
         {% for type in shop.enabled_payment_types %}
           {% if payment_icons_available contains type %}

--- a/src/sections/footer.liquid
+++ b/src/sections/footer.liquid
@@ -29,6 +29,7 @@
             <li>
               {%- assign icon_name = type | prepend: 'icon-' -%}
               {% include icon_name %}
+              <span class="visually-hidden">{{ type | capitalize | replace: '_', ' ' }}</span>
             </li>
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #86. The output for the payment icons in the footer now look like:

![image](https://cloud.githubusercontent.com/assets/991693/26111929/7cb2c8e8-3a24-11e7-9f0b-6258dbec9c5d.png)

