### PR TITLE
Modify checks for empty drops

### DIFF
--- a/src/sections/collection-list.liquid
+++ b/src/sections/collection-list.liquid
@@ -6,18 +6,18 @@
   <div {{ block.shopify_attributes }}>
     {%- assign collection = collections[block.settings.collection] -%}
 
-    <a href="{% if collection.empty? %}#{% else %}{{ collection.url }}{% endif %}">
+    <a href="{% if collection == empty %}#{% else %}{{ collection.url }}{% endif %}">
       {% if collection.image != blank %}
         {{ collection | img_url: '480x480' | img_tag: collection.title }}
       {% elsif collection.products.first != blank %}
         {{ collection.products.first | img_url: '480x480' | img_tag: collection.title }}
-      {% elsif collection.empty? %}
+      {% elsif collection == empty %}
         {% capture current %}{% cycle 1, 2, 3, 4, 5, 6 %}{% endcapture %}
         {{ 'collection-' | append: current | placeholder_svg_tag: 'placeholder-svg placeholder-svg--small' }}
       {% endif %}
 
       <p>
-        {% if collection.empty? %}
+        {% if collection == empty %}
           {{ 'homepage.onboarding.collection_title' | t }}
         {% else %}
           {{ collection.title }}

--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -1,7 +1,7 @@
 {%- assign product = all_products[section.settings.product] -%}
 {%- assign current_variant = product.selected_or_first_available_variant -%}
 
-{% if product.empty? %}
+{% if product == empty %}
   {%- assign section_onboarding = true -%}
   {%- assign onboarding_title = 'homepage.onboarding.product_title' | t -%}
 {% endif %}
@@ -121,7 +121,7 @@
     {% include 'social-sharing', share_title: product.title, share_permalink: product.url, share_image: product %}
   {% endif %}
 
-  {% unless product.empty? %}
+  {% unless product == empty %}
     <script type="application/json" data-product-json>
       {{ product | json }}
     </script>

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -111,7 +111,7 @@
     {% include 'social-sharing', share_title: product.title, share_permalink: product.url, share_image: product %}
   {% endif %}
 
-  {% unless product.empty? %}
+  {% unless product == empty %}
     <script type="application/json" data-product-json>
       {{ product | json }}
     </script>


### PR DESCRIPTION
Fixes #89.

Reference in documentation for proper empty drop usage: https://help.shopify.com/themes/liquid/basics/types#emptydrop