### PR TITLE
remove theme-support email, not theirs to support

### DIFF
--- a/src/config/settings_schema.json
+++ b/src/config/settings_schema.json
@@ -2,10 +2,10 @@
   {
     "name": "theme_info",
     "theme_name": "Slate",
-    "theme_version": "1.0.0",
+    "theme_version": "0.10.0",
     "theme_author": "Shopify",
     "theme_documentation_url": "https://github.com/Shopify/slate",
-    "theme_support_email": "theme-support@shopify.com"
+    "theme_support_url": "https://shopify.github.io/slate/"
   },
   {
     "name": "Typography",

--- a/src/config/settings_schema.json
+++ b/src/config/settings_schema.json
@@ -4,8 +4,8 @@
     "theme_name": "Slate",
     "theme_version": "0.10.0",
     "theme_author": "Shopify",
-    "theme_documentation_url": "https://github.com/Shopify/slate",
-    "theme_support_url": "https://shopify.github.io/slate/"
+    "theme_documentation_url": "https://shopify.github.io/slate/",
+    "theme_support_url": "https://github.com/Shopify/slate"
   },
   {
     "name": "Typography",


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Update the `theme_info` to remove Theme Support as the support email.  That group is not responsible for maintaining the code base.  

Switched it for `theme_support_url` so theme devs still know that you can separate the ideas of documentations and support.

Changed the theme version number to represent what we do for internally developed themes where the `theme_version` matches the `package.json` version. 


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

