### PR TITLE
use product drop for detecting default variant

### DIFF
--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -41,13 +41,11 @@
     <link itemprop="availability" href="http://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}">
 
     <form action="/cart/add" method="post" enctype="multipart/form-data">
-      {% unless product.variants.size == 1 and product.options.size == 1 and product.options.first == 'Title' and product.variants.first.title == 'Default Title' %}
+      {% unless product.has_only_default_variant %}
         {% for option in product.options_with_values %}
           <div class="selector-wrapper js">
-            <label
-              {% if option.name == 'default' %}class="label-hidden"{% endif %}
-              for="SingleOptionSelector-{{ section.id }}-{{ forloop.index0 }}">
-                {{ option.name }}
+            <label for="SingleOptionSelector-{{ section.id }}-{{ forloop.index0 }}">
+              {{ option.name }}
             </label>
 
             <select

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -3,7 +3,7 @@
   {%- assign current_variant = product.selected_or_first_available_variant -%}
   {%- assign featured_image = current_variant.featured_image | default: product.featured_image -%}
 
-  <meta itemprop="name" content="{{ product.title }}{% unless current_variant.title == 'Default Title' %} - {{ current_variant.title }}{% endunless %}">
+  <meta itemprop="name" content="{{ product.title }}{% unless product.has_only_default_variant %} - {{ current_variant.title }}{% endunless %}">
   <meta itemprop="url" content="{{ shop.url }}{{ current_variant.url }}">
   <meta itemprop="brand" content="{{ product.vendor }}">
   <meta itemprop="image" content="{{ featured_image | img_url: '600x600' }}">
@@ -32,13 +32,11 @@
     <link itemprop="availability" href="http://schema.org/{% if current_variant.available %}InStock{% else %}OutOfStock{% endif %}">
 
     <form action="/cart/add" method="post" enctype="multipart/form-data">
-      {% unless product.variants.size == 1 and product.options.size == 1 and product.options.first == 'Title' and product.variants.first.title == 'Default Title' %}
+      {% unless product.has_only_default_variant %}
         {% for option in product.options_with_values %}
           <div class="selector-wrapper js">
-            <label
-              {% if option.name == 'default' %}class="label-hidden"{% endif %}
-              for="SingleOptionSelector-{{ forloop.index0 }}">
-                {{ option.name }}
+            <label for="SingleOptionSelector-{{ forloop.index0 }}">
+              {{ option.name }}
             </label>
 
             <select

--- a/src/templates/cart.liquid
+++ b/src/templates/cart.liquid
@@ -32,8 +32,8 @@
             <td>
               <a href="{{ item.url }}">{{ item.product.title }}</a>
 
-              {% unless item.variant.title contains 'Default' %}
-              <p>{{ item.variant.title }}</p>
+              {% unless item.product.has_only_default_variant %}
+                <p>{{ item.variant.title }}</p>
               {% endunless %}
 
               <p>{{ item.vendor }}</p>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

There is a new product drop used for detecting whether a product only has the default variant: `product.has_only_default_variant`.  (Public docs are being updated and in review)

This PR removes the complicated and fragile check for "default product option" values.  This detection is now moved to Shopify's side.

#### Other notes

I removed `{% if option.name == 'default' %}class="label-hidden"{% endif %}` on the `<label>` elements.  Reason: If the merchant has left the product option as "Default" in the admin, then we'll display it here.  The new drop will take care of the single default variant check earlier in the markup.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

