### PR TITLE
add a sample gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 node_modules
 _site
 dist
+upload
 /.idea
 deploy.log
 config.yml

--- a/.gitignore-sample
+++ b/.gitignore-sample
@@ -9,6 +9,7 @@
 ###################
 node_modules
 dist
+upload
 deploy.log
 config.yml
 

--- a/.gitignore-sample
+++ b/.gitignore-sample
@@ -1,0 +1,60 @@
+# This file contains a list of files and folders to be ignored when
+# committing to a git repository.  Ignored files are both Slate project
+# specific files as well as commonly ignored files on any project.
+
+# For more information on this .gitignore files, see GitHub's
+# documentation: https://help.github.com/articles/ignoring-files/
+
+# Project #
+###################
+node_modules
+dist
+deploy.log
+config.yml
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Custom #
+######################
+*.sass-cache*
+_site
+/.idea
+secrets.json
+.jekyll-metadata
+.ruby-version

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,6 @@ The steps below walk through installing Slate globally and configuring your deve
 
 ## Working with `git`
 
-A new Slate project comes with a `.gitignore-sample` file.  This file is meant to be a starting point for your own `.gitignore` file if you will be using `git` for version control. The sample files contains a list of files and folders to be ignored when committing to a git repository.  Ignored files are both Slate project specific files as well as commonly ignored files on any project.
+A new Slate project comes with a `.gitignore-sample` file.  This file is meant to be a starting point for your own `.gitignore` file if you will be using `git` for version control. The sample files contains a list of files and folders to be ignored when committing to a git repository. Ignored files are both Slate project specific files as well as commonly ignored files on any project.
 
-For more information on this `.gitignore` files, see GitHub's documentation: https://help.github.com/articles/ignoring-files/
+For more information on `.gitignore` files, see GitHub's documentation: https://help.github.com/articles/ignoring-files/

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,3 +46,9 @@ The steps below walk through installing Slate globally and configuring your deve
 * `slate zip` — Builds and compresses your `dist` to a zip file for easy manual upload
 
 > Learn more about [all commands and descriptions](/slate/commands/) or how to [deploy to multiple environments](/slate/commands/#sync-commands).
+
+## Working with `git`
+
+A new Slate project comes with a `.gitignore-sample` file.  This file is meant to be a starting point for your own `.gitignore` file if you will be using `git` for version control. The sample files contains a list of files and folders to be ignored when committing to a git repository.  Ignored files are both Slate project specific files as well as commonly ignored files on any project.
+
+For more information on this `.gitignore` files, see GitHub's documentation: https://help.github.com/articles/ignoring-files/

--- a/scripts/build
+++ b/scripts/build
@@ -36,4 +36,4 @@ function _buildZip(name, directories = [], files = []) {
   archive.finalize();
 }
 
-_buildZip('slate-src', ['src'], ['config-sample.yml']);
+_buildZip('slate-src', ['src'], ['config-sample.yml', '.gitignore-sample']);


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Partially address https://github.com/Shopify/slate/issues/126

Creating a sample gitignore tailored for a new Slate project.  The `.gitignore-sample` file is now part of `slate-src.zip` which is used by the `theme.js` command in `slate-cli`.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

