### PR TITLE
trapFocus() - Replace eventNameSpace with namespace

### DIFF
--- a/src/scripts/slate/a11y.js
+++ b/src/scripts/slate/a11y.js
@@ -63,8 +63,8 @@ slate.a11y = {
    * @param {string} options.namespace - Namespace used for new focus event handler
    */
   trapFocus: function(options) {
-    var eventName = options.eventNamespace
-      ? 'focusin.' + options.eventNamespace
+    var eventName = options.namespace
+      ? 'focusin.' + options.namespace
       : 'focusin';
 
     if (!options.$elementToFocus) {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fix #186.

Updated the `eventName` variable with the proper object property.