### PR TITLE
Fix behaviour and errors when no product image

### DIFF
--- a/packages/slate-theme/src/scripts/sections/product.js
+++ b/packages/slate-theme/src/scripts/sections/product.js
@@ -37,7 +37,6 @@ theme.Product = (function() {
     }
 
     var sectionId = this.$container.attr('data-section-id');
-    var $featuredImage = $(selectors.productFeaturedImage, this.$container);
     var options = {
       $container: this.$container,
       enableHistoryState: this.$container.data('enable-history-state') || false,
@@ -49,13 +48,14 @@ theme.Product = (function() {
     this.settings = {};
     this.namespace = '.product';
     this.variants = new slate.Variants(options);
+    this.$featuredImage = $(selectors.productFeaturedImage, this.$container);
     this.productSingleObject = JSON.parse($(selectors.productJson, this.$container).html());
 
     this.$container.on('variantChange' + this.namespace, this.updateAddToCartState.bind(this));
     this.$container.on('variantPriceChange' + this.namespace, this.updateProductPrices.bind(this));
 
-    if ($featuredImage.length > 0) {
-      this.settings.imageSize = slate.Image.imageSize($(selectors.productFeaturedImage, this.$container).attr('src'));
+    if (this.$featuredImage.length > 0) {
+      this.settings.imageSize = slate.Image.imageSize(this.$featured_image.attr('src'));
       slate.Image.preload(this.productSingleObject.images, this.settings.imageSize);
 
       this.$container.on('variantImageChange' + this.namespace, this.updateProductImage.bind(this));
@@ -122,9 +122,8 @@ theme.Product = (function() {
     updateProductImage: function(evt) {
       var variant = evt.variant;
       var sizedImgUrl = slate.Image.getSizedImageUrl(variant.featured_image.src, this.settings.imageSize);
-      var $image = $(selectors.productFeaturedImage, this.$container);
 
-      $(selectors.productFeaturedImage, this.$container).attr('src', sizedImgUrl);
+      this.$featured_image.attr('src', sizedImgUrl);
     },
 
     /**

--- a/packages/slate-theme/src/sections/featured-collection.liquid
+++ b/packages/slate-theme/src/sections/featured-collection.liquid
@@ -6,7 +6,11 @@
 
 {% for product in collection.products limit: 6 %}
   <a href="{{ product.url | within: collection }}">
-    {{ product.featured_image.src | img_url: '480x480' | img_tag: product.title }}
+
+    {% if product.featured_image != blank %}
+      {{ product.featured_image.src | img_url: '480x480' | img_tag: product.title }}
+    {% endif %}
+
     <p>{{ product.title }}</p>
   </a>
 

--- a/packages/slate-theme/src/sections/featured-product.liquid
+++ b/packages/slate-theme/src/sections/featured-product.liquid
@@ -1,5 +1,6 @@
 {%- assign product = all_products[section.settings.product] -%}
 {%- assign current_variant = product.selected_or_first_available_variant -%}
+{%- assign featured_image = current_variant.featured_image | default: product.featured_image -%}
 
 {% if product == empty %}
   {%- assign section_onboarding = true -%}
@@ -9,13 +10,11 @@
 <div data-section-id="{{ section.id }}" data-section-type="product" itemscope itemtype="http://schema.org/Product">
   <meta itemprop="name" content="{{ product.title }}">
   <meta itemprop="url" content="{{ shop.url }}{{ product.url }}">
-  <meta itemprop="image" content="{{ product.featured_image.src | img_url: '800x' }}">
+  <meta itemprop="image" content="{{ featured_image | img_url: '800x' }}">
   <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
 
-  {% if product.featured_image.src != blank %}
-    <img src="{{ product.featured_image.src | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>
-  {% else %}
-    {{ 'product-1' | placeholder_svg_tag: 'placeholder-svg placeholder-svg--small' }}
+  {% if featured_image.src != blank %}
+    <img src="{{ featured_image | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>
   {% endif %}
 
   {% if product.images.size > 1 %}

--- a/packages/slate-theme/src/sections/product.liquid
+++ b/packages/slate-theme/src/sections/product.liquid
@@ -9,7 +9,10 @@
   <meta itemprop="image" content="{{ featured_image | img_url: '600x600' }}">
   <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
 
-  <img src="{{ featured_image | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>
+  {% if featured_image != blank %}
+    <img src="{{ featured_image | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>
+  {% endif %}
+
   {% if product.images.size > 1 %}
     <ul>
       {% for image in product.images %}
@@ -21,7 +24,6 @@
       {% endfor %}
     </ul>
   {% endif %}
-
 
   <h1>{{ product.title }}</h1>
   <p>{{ product.vendor }}</p>

--- a/packages/slate-theme/src/templates/cart.liquid
+++ b/packages/slate-theme/src/templates/cart.liquid
@@ -29,7 +29,7 @@
 
               {% if item.image != blank %}
                 <a href="{{ item.url | within: collections.all }}">
-                  <img src="{{ item | img_url: '240x240' }}" alt="{{ item.title | escape }}">
+                  {{ item | img_url: '240x240' | img_tag: item.title }}
                 </a>
               {% endif %}
 

--- a/packages/slate-theme/src/templates/cart.liquid
+++ b/packages/slate-theme/src/templates/cart.liquid
@@ -24,10 +24,15 @@
         {% endcomment %}
 
           <tr class="responsive-table-row">
+
             <td data-label="{{ 'customer.order.product' | t }}">
-              <a href="{{ item.url | within: collections.all }}">
-                <img src="{{ item | img_url: '240x240' }}" alt="{{ item.title | escape }}">
-              </a>
+
+              {% if item.image != blank %}
+                <a href="{{ item.url | within: collections.all }}">
+                  <img src="{{ item | img_url: '240x240' }}" alt="{{ item.title | escape }}">
+                </a>
+              {% endif %}
+
             </td>
             <td>
               <a href="{{ item.url }}">{{ item.product.title }}</a>

--- a/packages/slate-theme/src/templates/collection.liquid
+++ b/packages/slate-theme/src/templates/collection.liquid
@@ -27,9 +27,11 @@
   <div>
     {% for product in collection.products %}
       <div>
-        <a href="{{ product.url | within: collection }}">
-          <img src="{{ product.featured_image.src | img_url: '480x480' }}" alt="{{ product.featured_image.alt | escape }}">
-        </a>
+        {% if product.featured_image != blank %}
+          <a href="{{ product.url | within: collection }}">
+            <img src="{{ product.featured_image.src | img_url: '480x480' }}" alt="{{ product.featured_image.alt | escape }}">
+          </a>
+        {% endif %}
 
         <p>
           <a href="{{ product.url | within: collection }}">{{ product.title }}</a>

--- a/packages/slate-theme/src/templates/collection.liquid
+++ b/packages/slate-theme/src/templates/collection.liquid
@@ -29,7 +29,7 @@
       <div>
         {% if product.featured_image != blank %}
           <a href="{{ product.url | within: collection }}">
-            <img src="{{ product.featured_image.src | img_url: '480x480' }}" alt="{{ product.featured_image.alt | escape }}">
+            {{ product.featured_image.src | img_url: '480x480' | img_tag: product.featured_image.alt }}
           </a>
         {% endif %}
 

--- a/packages/slate-theme/src/templates/search.liquid
+++ b/packages/slate-theme/src/templates/search.liquid
@@ -32,9 +32,9 @@
     <ul>
       {% for item in search.results %}
         <li>
-          {% if item.featured_image %}
+          {% if item.image != blank %}
             <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
-              {{ item.featured_image.src | img_url: '240x240' | img_tag: item.featured_image.alt }}
+              {{ item | img_url: '240x240' | img_tag: item.featured_image.alt }}
             </a>
           {% endif %}
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/99

- Fixes `feature-product.liquid` section by removing placeholder image if no image is set. Also matches `product.liquid` section behaviour by setting the featured image as either the current variant's featured image or the product featured image
- Fixes `product.liquid` by checking if featured image is not black
- Fixes `product.js` by only performing image functions if an image is present on the page. There was some code that was rearranged to make this check easy.

For maintainers:
- [ ] I have :tophat:'d these changes.

