### PR TITLE
Ignore watching dot files in dist/ directory

### DIFF
--- a/packages/slate-tools/src/tasks/build-assets.js
+++ b/packages/slate-tools/src/tasks/build-assets.js
@@ -82,10 +82,12 @@ gulp.task('build:assets', () => {
 gulp.task('watch:assets', () => {
   const eventCache = utils.createEventCache();
 
-  chokidar.watch(assetsPaths, {ignoreInitial: true})
-    .on('all', (event, path) => {
-      messages.logFileEvent(event, path);
-      eventCache.addEvent(event, path);
-      utils.processCache(eventCache, processAssets, removeAssets);
-    });
+  chokidar.watch(assetsPaths, {
+    ignored: /(^|[/\\])\../,
+    ignoreInitial: true,
+  }).on('all', (event, path) => {
+    messages.logFileEvent(event, path);
+    eventCache.addEvent(event, path);
+    utils.processCache(eventCache, processAssets, removeAssets);
+  });
 });

--- a/packages/slate-tools/src/tasks/watchers.js
+++ b/packages/slate-tools/src/tasks/watchers.js
@@ -105,6 +105,7 @@ gulp.task('watch:src', [
 gulp.task('watch:dist', () => {
   const watcher = chokidar.watch(['./', '!config.yml'], {
     cwd: config.dist.root,
+    ignored: /(^|[/\\])\../,
     ignoreInitial: true,
   });
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/227

Ignores watching `.DS_store` and any other dot files in the `dist/` directory.

For maintainers:
- [ ] I have :tophat:'d these changes.

