### PR TITLE
add charset to stylesheet

### DIFF
--- a/packages/slate-theme/src/styles/theme.scss
+++ b/packages/slate-theme/src/styles/theme.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*============================================================================
   [replace with theme name] | Built with Slate
     - You cannot use native CSS/Sass @imports in this file without a build script


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

When developers add certain UTF-8 characters to their `theme.scss` file such as a trademark symbol `©`, an accent such as `ë`, or a proud deer `🦌`, the stylesheet will not load properly on storefront.
This was first noted in https://github.com/Shopify/slate/issues/204 and again in https://github.com/Shopify/slate/issues/241.

This PR adds the fix to the main stylesheet.  Hopefully this will prevent future devs from running into this issue.   🙏🔮😄

#### Fix in action

![](https://screenshot.click/Slate_Webinar_2017-08-20_21-38-04.png)


### Other notes
The broken stylesheet behaviour is only seen outside the theme editor.  Within the theme editor, the stylesheet loads fine because the asset goes through a separate build process than storefront.


### Checklist

For maintainers:
- [ ] I have :tophat:'d these changes.

