### PR TITLE
Fix the output of slate-src.zip

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const path = require('path');
 const archiver = require('archiver');
 
 /**
@@ -26,11 +27,11 @@ function _buildZip(name, directories = [], files = []) {
   archive.pipe(output);
 
   directories.forEach((directory) => {
-    archive.directory(directory);
+    archive.directory(directory, '/src');
   });
 
   files.forEach((file) => {
-    archive.file(file);
+    archive.file(file, { name: path.join('/', path.basename(file)) });
   });
 
   archive.finalize();


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

[`slate-src.zip v0.12.0`](https://sdks.shopifycdn.com/slate/0.12.0/slate-src.zip) has its files in the `packages/slate-theme` directory. This patch fixes the zip to be the same structure as <v0.12.0.

cc @chrisberthe @NathanPJF 