### PR TITLE
Fix typo and variable declaration order in product.js

### DIFF
--- a/packages/slate-theme/src/scripts/sections/product.js
+++ b/packages/slate-theme/src/scripts/sections/product.js
@@ -37,6 +37,8 @@ theme.Product = (function() {
     }
 
     var sectionId = this.$container.attr('data-section-id');
+    this.productSingleObject = JSON.parse($(selectors.productJson, this.$container).html());
+
     var options = {
       $container: this.$container,
       enableHistoryState: this.$container.data('enable-history-state') || false,
@@ -49,13 +51,12 @@ theme.Product = (function() {
     this.namespace = '.product';
     this.variants = new slate.Variants(options);
     this.$featuredImage = $(selectors.productFeaturedImage, this.$container);
-    this.productSingleObject = JSON.parse($(selectors.productJson, this.$container).html());
 
     this.$container.on('variantChange' + this.namespace, this.updateAddToCartState.bind(this));
     this.$container.on('variantPriceChange' + this.namespace, this.updateProductPrices.bind(this));
 
     if (this.$featuredImage.length > 0) {
-      this.settings.imageSize = slate.Image.imageSize(this.$featured_image.attr('src'));
+      this.settings.imageSize = slate.Image.imageSize(this.$featuredImage.attr('src'));
       slate.Image.preload(this.productSingleObject.images, this.settings.imageSize);
 
       this.$container.on('variantImageChange' + this.namespace, this.updateProductImage.bind(this));


### PR DESCRIPTION
- scripts/sections/product.js, this.productSingleObject needs to be initialized before using it in options object.

- line 59, scripts/sections/product.js, this.$featured_image is not a defined variable (it's a typo), needs to be replaced with this.$featuredImage

### What are you trying to accomplish with this PR?
Some basic fixes in scripts/sections/product.js

*Please provide a link to the associated GitHub issue.*


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

