### PR TITLE
Tracking information for order page

### DIFF
--- a/packages/slate-theme/src/locales/da.json
+++ b/packages/slate-theme/src/locales/da.json
@@ -183,9 +183,10 @@
       "price": "Pris",
       "quantity": "Antal",
       "total": "Total",
-      "fulfilled_at": "Opfyldt {{ date }}",
+      "fulfilled_at": "Dato opfyldt",
       "track_shipment": "Spor forsendelse",
-      "tracking_company": "Selskab",
+      "tracking_url": "Tracking link",
+      "tracking_company": "Bedrijf",
       "tracking_number": "Sporingsnummer",
       "subtotal": "Sub total"
     },

--- a/packages/slate-theme/src/locales/da.json
+++ b/packages/slate-theme/src/locales/da.json
@@ -184,6 +184,9 @@
       "quantity": "Antal",
       "total": "Total",
       "fulfilled_at": "Opfyldt {{ date }}",
+      "track_shipment": "Spor forsendelse",
+      "tracking_company": "Selskab",
+      "tracking_number": "Sporingsnummer",
       "subtotal": "Sub total"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/de.json
+++ b/packages/slate-theme/src/locales/de.json
@@ -184,6 +184,9 @@
       "quantity": "Menge",
       "total": "Gesamt",
       "fulfilled_at": "Geliefert am {{ date }}",
+      "track_shipment": "Sendung verfolgen",
+      "tracking_company": "Unternehmen",
+      "tracking_number": "Sendungscode",
       "subtotal": "Zwischensumme"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/de.json
+++ b/packages/slate-theme/src/locales/de.json
@@ -183,8 +183,9 @@
       "price": "Preis",
       "quantity": "Menge",
       "total": "Gesamt",
-      "fulfilled_at": "Geliefert am {{ date }}",
+      "fulfilled_at": "Datum abgeschlossen",
       "track_shipment": "Sendung verfolgen",
+      "tracking_url": "Tracking link",
       "tracking_company": "Unternehmen",
       "tracking_number": "Sendungscode",
       "subtotal": "Zwischensumme"

--- a/packages/slate-theme/src/locales/en.default.json
+++ b/packages/slate-theme/src/locales/en.default.json
@@ -184,6 +184,9 @@
       "quantity": "Quantity",
       "total": "Total",
       "fulfilled_at": "Fulfilled {{ date }}",
+      "track_shipment": "Track shipment",
+      "tracking_company": "Company",
+      "tracking_number": "Tracking number",
       "subtotal": "Subtotal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/en.default.json
+++ b/packages/slate-theme/src/locales/en.default.json
@@ -183,8 +183,9 @@
       "price": "Price",
       "quantity": "Quantity",
       "total": "Total",
-      "fulfilled_at": "Fulfilled {{ date }}",
+      "fulfilled_at": "Date fulfilled",
       "track_shipment": "Track shipment",
+      "tracking_url": "Tracking link",
       "tracking_company": "Company",
       "tracking_number": "Tracking number",
       "subtotal": "Subtotal"

--- a/packages/slate-theme/src/locales/es.json
+++ b/packages/slate-theme/src/locales/es.json
@@ -184,6 +184,9 @@
       "quantity": "Cantidad",
       "total": "Total",
       "fulfilled_at": "Finalizado {{ date }}",
+      "track_shipment": "Rastrear envío",
+      "tracking_company": "Empresa",
+      "tracking_number": "Número de seguimiento",
       "subtotal": "Subtotal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/es.json
+++ b/packages/slate-theme/src/locales/es.json
@@ -183,8 +183,9 @@
       "price": "Precio",
       "quantity": "Cantidad",
       "total": "Total",
-      "fulfilled_at": "Finalizado {{ date }}",
+      "fulfilled_at": "Fecha cumplió",
       "track_shipment": "Rastrear envío",
+      "tracking_url": "Enlace de seguimiento",
       "tracking_company": "Empresa",
       "tracking_number": "Número de seguimiento",
       "subtotal": "Subtotal"

--- a/packages/slate-theme/src/locales/fr.json
+++ b/packages/slate-theme/src/locales/fr.json
@@ -183,8 +183,9 @@
       "price": "Prix",
       "quantity": "Quantité",
       "total": "Total",
-      "fulfilled_at": "Traitée le {{ date }}",
+      "fulfilled_at": "Date traitée",
       "track_shipment": "Retracer l'envoi",
+      "tracking_url": "Lien de suivi",
       "tracking_company": "Compagnie",
       "tracking_number": "Numéro de suivi",
       "subtotal": "Sous-total"

--- a/packages/slate-theme/src/locales/fr.json
+++ b/packages/slate-theme/src/locales/fr.json
@@ -184,6 +184,9 @@
       "quantity": "Quantité",
       "total": "Total",
       "fulfilled_at": "Traitée le {{ date }}",
+      "track_shipment": "Retracer l'envoi",
+      "tracking_company": "Compagnie",
+      "tracking_number": "Numéro de suivi",
       "subtotal": "Sous-total"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/nl.json
+++ b/packages/slate-theme/src/locales/nl.json
@@ -183,8 +183,9 @@
       "price": "Prijs",
       "quantity": "Hoeveelheid",
       "total": "Totaal",
-      "fulfilled_at": "Verzonden op {{ date }}",
+      "fulfilled_at": "Datum vervuld",
       "track_shipment": "Track verzending",
+      "tracking_url": "Tracking link",
       "tracking_company": "Bedrijf",
       "tracking_number": "Volgnummer",
       "subtotal": "Subtotaal"

--- a/packages/slate-theme/src/locales/nl.json
+++ b/packages/slate-theme/src/locales/nl.json
@@ -184,6 +184,9 @@
       "quantity": "Hoeveelheid",
       "total": "Totaal",
       "fulfilled_at": "Verzonden op {{ date }}",
+      "track_shipment": "Track verzending",
+      "tracking_company": "Bedrijf",
+      "tracking_number": "Volgnummer",
       "subtotal": "Subtotaal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/nl.json
+++ b/packages/slate-theme/src/locales/nl.json
@@ -96,7 +96,7 @@
   "collections": {
     "general": {
       "no_matches": "Sorry, er bevinden zich geen producten in deze collectie",
-      "link_title": "Bekijk onze {{ title }} collectie",
+      "link_title": "Bekijk onze {{ title }} collectie"
     }
   },
   "contact": {
@@ -251,7 +251,7 @@
       "on_sale_from_html": "In sale van {{ price }}",
       "from_text_html": "Vanaf {{ price }}",
       "quantity": "Aantal",
-      "add_to_cart": "In winkelmandje",
+      "add_to_cart": "In winkelmandje"
     }
   },
   "gift_cards": {

--- a/packages/slate-theme/src/locales/pt-BR.json
+++ b/packages/slate-theme/src/locales/pt-BR.json
@@ -184,6 +184,9 @@
       "quantity": "Quantidade",
       "total": "Total",
       "fulfilled_at": "Processado em {{ date }}",
+      "track_shipment": "Rastreie o pacote",
+      "tracking_company": "Empresa",
+      "tracking_number": "Numero de rastreio",
       "subtotal": "Subtotal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/pt-BR.json
+++ b/packages/slate-theme/src/locales/pt-BR.json
@@ -183,8 +183,9 @@
       "price": "Preço",
       "quantity": "Quantidade",
       "total": "Total",
-      "fulfilled_at": "Processado em {{ date }}",
+      "fulfilled_at": "Fecha de procesamiento",
       "track_shipment": "Rastreie o pacote",
+      "tracking_url": "Link de rastreio",
       "tracking_company": "Empresa",
       "tracking_number": "Numero de rastreio",
       "subtotal": "Subtotal"

--- a/packages/slate-theme/src/locales/pt-PT.json
+++ b/packages/slate-theme/src/locales/pt-PT.json
@@ -186,7 +186,7 @@
       "fulfilled_at": "Concluído em {{ date }}",
       "track_shipment": "Acompanhar envio",
       "tracking_company": "Empresa",
-      "tracking_number": "Numero de rastreio",
+      "tracking_number": "Numero de acompanhamento",
       "subtotal": "Subtotal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/locales/pt-PT.json
+++ b/packages/slate-theme/src/locales/pt-PT.json
@@ -183,8 +183,9 @@
       "price": "Preço",
       "quantity": "Quantidade",
       "total": "Total",
-      "fulfilled_at": "Concluído em {{ date }}",
+      "fulfilled_at": "Fecha de finalización",
       "track_shipment": "Acompanhar envio",
+      "tracking_url": "Link de acompanhamento",
       "tracking_company": "Empresa",
       "tracking_number": "Numero de acompanhamento",
       "subtotal": "Subtotal"

--- a/packages/slate-theme/src/locales/pt-PT.json
+++ b/packages/slate-theme/src/locales/pt-PT.json
@@ -184,6 +184,9 @@
       "quantity": "Quantidade",
       "total": "Total",
       "fulfilled_at": "Concluído em {{ date }}",
+      "track_shipment": "Acompanhar envio",
+      "tracking_company": "Empresa",
+      "tracking_number": "Numero de rastreio",
       "subtotal": "Subtotal"
     },
     "recover_password": {

--- a/packages/slate-theme/src/templates/customers/order.liquid
+++ b/packages/slate-theme/src/templates/customers/order.liquid
@@ -33,26 +33,28 @@
         <td data-label="{{ 'customer.order.product' | t }}">
           {{ line_item.title | link_to: line_item.product.url }}
           {% if line_item.fulfillment %}
-            <div>
-              {%- assign created_at = line_item.fulfillment.created_at | date: format: 'month_day_year' -%}
-                <div>
-                  {{ 'customer.order.fulfilled_at' | t: date: created_at }}
-                </div>
-                {% if line_item.fulfillment.tracking_url %}
+            <dl>
+              <dt>{{ 'customer.order.fulfilled_at' | t }}</dt>
+              <dd>{{ line_item.fulfillment.created_at | date: format: 'month_day_year' }}</dd>
+
+              {% if line_item.fulfillment.tracking_url %}
+                <dt>{{ 'customer.order.tracking_url' | t }}</dt>
+                <dd>
                   <a href="{{ line_item.fulfillment.tracking_url }}">
                     {{ 'customer.order.track_shipment' | t }}
                   </a>
-                {% endif %}
-                <div>
-                  {{ 'customer.order.tracking_company' | t }}: {{ line_item.fulfillment.tracking_company }}
-                </div>
-                {% if line_item.fulfillment.tracking_number %}
-                  <div>
-                    {{ 'customer.order.tracking_number' | t }}: {{ line_item.fulfillment.tracking_number }}
-                  </div>
-                {% endif %}
-              </p>
-            </div>
+                </dd>
+              {% endif %}
+
+              <dt>{{ 'customer.order.tracking_company' | t }}</dt>
+              <dd>{{ line_item.fulfillment.tracking_company }}</dd>
+
+
+              {% if line_item.fulfillment.tracking_number %}
+                <dt>{{ 'customer.order.tracking_number' | t }}</dt>
+                <dd>{{ line_item.fulfillment.tracking_number }}</dd>
+              {% endif %}
+            </dl>
           {% endif %}
         </td>
         <td data-label="{{ 'customer.order.sku' | t }}">{{ line_item.sku }}</td>

--- a/packages/slate-theme/src/templates/customers/order.liquid
+++ b/packages/slate-theme/src/templates/customers/order.liquid
@@ -35,20 +35,23 @@
           {% if line_item.fulfillment %}
             <div>
               {%- assign created_at = line_item.fulfillment.created_at | date: format: 'month_day_year' -%}
-              <ul>
-                <li>{{ 'customer.order.fulfilled_at' | t: date: created_at }}</li>
+                <div>
+                  {{ 'customer.order.fulfilled_at' | t: date: created_at }}
+                </div>
                 {% if line_item.fulfillment.tracking_url %}
-                  <li>
-                    <a href="{{ line_item.fulfillment.tracking_url }}">
-                      {{ 'customer.order.track_shipment' | t }}
-                    </a>
-                  </li>
+                  <a href="{{ line_item.fulfillment.tracking_url }}">
+                    {{ 'customer.order.track_shipment' | t }}
+                  </a>
                 {% endif %}
-              <li>Company: {{ line_item.fulfillment.tracking_company }}</li>
-              {%- if line_item.fulfillment.tracking_number -%}
-                <li>Tracking number: {{ line_item.fulfillment.tracking_number }}</li>
-              {%- endif -%}
-              </ul>
+                <div>
+                  {{ 'customer.order.tracking_company' | t }}: {{ line_item.fulfillment.tracking_company }}
+                </div>
+                {% if line_item.fulfillment.tracking_number %}
+                  <div>
+                    {{ 'customer.order.tracking_number' | t }}: {{ line_item.fulfillment.tracking_number }}
+                  </div>
+                {% endif %}
+              </p>
             </div>
           {% endif %}
         </td>

--- a/packages/slate-theme/src/templates/customers/order.liquid
+++ b/packages/slate-theme/src/templates/customers/order.liquid
@@ -49,7 +49,6 @@
               <dt>{{ 'customer.order.tracking_company' | t }}</dt>
               <dd>{{ line_item.fulfillment.tracking_company }}</dd>
 
-
               {% if line_item.fulfillment.tracking_number %}
                 <dt>{{ 'customer.order.tracking_number' | t }}</dt>
                 <dd>{{ line_item.fulfillment.tracking_number }}</dd>

--- a/packages/slate-theme/src/templates/customers/order.liquid
+++ b/packages/slate-theme/src/templates/customers/order.liquid
@@ -35,10 +35,20 @@
           {% if line_item.fulfillment %}
             <div>
               {%- assign created_at = line_item.fulfillment.created_at | date: format: 'month_day_year' -%}
-              {{ 'customer.order.fulfilled_at' | t: date: created_at }}
-              {% if line_item.fulfillment.tracking_number %}
-                <a href="{{ line_item.fulfillment.tracking_url }}">{{ line_item.fulfillment.tracking_company }} #{{ line_item.fulfillment.tracking_number}}</a>
-              {% endif %}
+              <ul>
+                <li>{{ 'customer.order.fulfilled_at' | t: date: created_at }}</li>
+                {% if line_item.fulfillment.tracking_url %}
+                  <li>
+                    <a href="{{ line_item.fulfillment.tracking_url }}">
+                      {{ 'customer.order.track_shipment' | t }}
+                    </a>
+                  </li>
+                {% endif %}
+              <li>Company: {{ line_item.fulfillment.tracking_company }}</li>
+              {%- if line_item.fulfillment.tracking_number -%}
+                <li>Tracking number: {{ line_item.fulfillment.tracking_number }}</li>
+              {%- endif -%}
+              </ul>
             </div>
           {% endif %}
         </td>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

A recent Liquid update to `fulfillment.tracking_url` had it stop returning a Google search URL if a tracking number was provided, but the tracking URL or company was unknown. Example: `http://www.google.com/search?q=78714763445730`. 

If the tracking URL is unknown, `{{ fulfillment.tracking_url }}` now returns `nil`. 

This PR is made to only output the tracking URL if it is known.  
To help customers who have no URL, this PR displays more information about the tracking company and tracking number if it is known.

Note: The tracking company always has a value in Shopify.  If none is provided, it will say "Other".

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

