### PR TITLE
Display the gift card's initial value

### DIFF
--- a/packages/slate-theme/src/locales/da.json
+++ b/packages/slate-theme/src/locales/da.json
@@ -266,7 +266,8 @@
       "shop_link": "Start med at handle",
       "print": "Print",
       "remaining_html": "{{ balance }} tilbage",
-      "add_to_apple_wallet": "Tilføj til Apple Wallet"
+      "add_to_apple_wallet": "Tilføj til Apple Wallet",
+      "initial_value": "Gavekortets værdi: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/de.json
+++ b/packages/slate-theme/src/locales/de.json
@@ -266,7 +266,8 @@
       "shop_link": "Einkauf beginnen",
       "print": "Drucken",
       "remaining_html": "{{ balance }} übrig",
-      "add_to_apple_wallet": "Hinzufügen zu Apple Wallet"
+      "add_to_apple_wallet": "Hinzufügen zu Apple Wallet",
+      "initial_value": "Geschenkkarten-Betrag: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/en.default.json
+++ b/packages/slate-theme/src/locales/en.default.json
@@ -266,7 +266,8 @@
       "shop_link": "Start shopping",
       "print": "Print",
       "remaining_html": "{{ balance }} left",
-      "add_to_apple_wallet": "Add to Apple Wallet"
+      "add_to_apple_wallet": "Add to Apple Wallet",
+      "initial_value": "Gift card value: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/es.json
+++ b/packages/slate-theme/src/locales/es.json
@@ -266,7 +266,8 @@
       "shop_link": "Empezar a comprar",
       "print": "Imprimir",
       "remaining_html": "{{ balance }} restante",
-      "add_to_apple_wallet": "Añadir a Apple Wallet"
+      "add_to_apple_wallet": "Añadir a Apple Wallet",
+      "initial_value": "Valor de la tarjeta de regalo: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/fr.json
+++ b/packages/slate-theme/src/locales/fr.json
@@ -266,7 +266,8 @@
       "shop_link": "Boutique",
       "print": "Imprimer",
       "remaining_html": "{{ balance }} restant",
-      "add_to_apple_wallet": "Ajouter à Apple Wallet"
+      "add_to_apple_wallet": "Ajouter à Apple Wallet",
+      "initial_value": "Valeur de la carte-cadeau : {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/nl.json
+++ b/packages/slate-theme/src/locales/nl.json
@@ -266,7 +266,8 @@
       "shop_link": "Begin te shoppen",
       "print": "Printen",
       "remaining_html": "{{ balance }} over",
-      "add_to_apple_wallet": "Voeg toe aan Apple Wallet"
+      "add_to_apple_wallet": "Voeg toe aan Apple Wallet",
+      "initial_value": "Waarde cadeaukaart: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/pt-BR.json
+++ b/packages/slate-theme/src/locales/pt-BR.json
@@ -266,7 +266,8 @@
       "shop_link": "Comece a comprar",
       "print": "Imprimir",
       "remaining_html": "{{ balance }} restantes",
-      "add_to_apple_wallet": "Adicionar ao Apple Wallet"
+      "add_to_apple_wallet": "Adicionar ao Apple Wallet",
+      "initial_value": "Valor do cartão presente: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/locales/pt-PT.json
+++ b/packages/slate-theme/src/locales/pt-PT.json
@@ -266,7 +266,8 @@
       "shop_link": "Começar a fazer compras",
       "print": "Imprimir",
       "remaining_html": "{{ balance }} restante",
-      "add_to_apple_wallet": "Adicionar ao Apple Wallet"
+      "add_to_apple_wallet": "Adicionar ao Apple Wallet",
+      "initial_value": "Valor do cartão oferta: {{ value }}"
     }
   },
   "date_formats":{

--- a/packages/slate-theme/src/templates/gift_card.liquid
+++ b/packages/slate-theme/src/templates/gift_card.liquid
@@ -36,10 +36,12 @@
 
   {% assign formatted_initial_value = gift_card.initial_value | money_without_trailing_zeros: gift_card.currency %}
 
-  <h2>Gift card value: {{ formatted_initial_value }}</h2>
+  <h2>{{ 'gift_cards.issued.initial_value' | t: value: formatted_initial_value }}</h2>
+
+  {% assign formatted_current_balance = gift_card.balance | money %}  
 
   {% if gift_card.balance != gift_card.initial_value %}
-    <p>Current balance: {{ 'gift_cards.issued.remaining_html' | t: balance: gift_card.balance | money }}</p>
+    <p>{{ 'gift_cards.issued.remaining_html' | t: balance: formatted_current_balance }}</p>
   {% endif %}
 
   {%- assign code_size = gift_card.code | format_code | size -%}

--- a/packages/slate-theme/src/templates/gift_card.liquid
+++ b/packages/slate-theme/src/templates/gift_card.liquid
@@ -34,11 +34,12 @@
 
   <img src="{{ 'gift-card/card.jpg' | shopify_asset_url }}" alt="Gift card illustration">
 
-  {%- assign initial_value_size = formatted_initial_value | size -%}
-  <h2>{{ formatted_initial_value }}</h2>
+  {% assign formatted_initial_value = gift_card.initial_value | money_without_trailing_zeros: gift_card.currency %}
+
+  <h2>Gift card value: {{ formatted_initial_value }}</h2>
 
   {% if gift_card.balance != gift_card.initial_value %}
-    <p>{{ 'gift_cards.issued.remaining_html' | t: balance: gift_card.balance | money }}</p>
+    <p>Current balance: {{ 'gift_cards.issued.remaining_html' | t: balance: gift_card.balance | money }}</p>
   {% endif %}
 
   {%- assign code_size = gift_card.code | format_code | size -%}


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Always display the gift card's initial value, which currently never shows up. The only value that appears is the card's balance, and that only appears when when it's not equal to the card's initial value. This should fix a [comment](https://github.com/Shopify/slate/issues/279#issuecomment-328591550) posted on issue #279. (fix #279)

### Checklist
- [x] I have :tophat:'d these changes.

