### PR TITLE
Ensure that slate documentation is indexed by search engines

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -6,8 +6,6 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <meta name="robots" content="noindex">
-
   <link rel="stylesheet" href="https://cdn.shopify.com/shopify-marketing_assets/builds/13.0.2/marketing_assets_content.css" media="screen" title="no title" charset="utf-8">
   <link rel="stylesheet" href="{{ "/css/prettify.min.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/css/yuidoc.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
### Ensure Slate documentation is indexed
Currently all the slate documentation has the meta tag "noindex" applied to it. This prevents search engines from index and showing the page in search results.

We can see that Google specifies [here](https://developers.google.com/search/reference/robots_meta_tag) what noindex means ("Do not show this page in search results and do not show a "Cached" link in search results.")

Since the default behavior is to index a page if it doesn't specify the meta robots tag we can safely just remove it

### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

