### PR TITLE
Fix Upload folder path in 'open:zip' gulp task

### DIFF
--- a/packages/slate-tools/src/tasks/deploy-utils.js
+++ b/packages/slate-tools/src/tasks/deploy-utils.js
@@ -170,5 +170,5 @@ gulp.task('open:admin', () => {
  * @static
  */
 gulp.task('open:zip', () => {
-  return open('./upload/');
+  return open('upload');
 });


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Fix #249. This PR fixes the `open:zip` Gulp task on Windows by changing the path to the Upload folder to be platform agnostic.

### Explanation
Since Windows and Unix-like operating systems use different path separators — backslashes in Windows (`\`) vs "common" slashes in Unix-like OSes (`/`) — the `open:zip` task would fail on Windows because of the Unix style slashes (`/`) used in the path to the `upload` folder.

### Checklist
For contributors:
- [X] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [X] I have :tophat:'d these changes.