### PR TITLE
Beautify settings files on migration

### DIFF
--- a/packages/slate-cli/src/commands/migrate.js
+++ b/packages/slate-cli/src/commands/migrate.js
@@ -4,7 +4,7 @@ import {join} from 'path';
 import {prompt} from 'inquirer';
 import {green, red, yellow} from 'chalk';
 import figures from 'figures';
-import {downloadFromUrl, startProcess, writePackageJsonSync, move, beautifyJson, isShopifyTheme, isShopifyThemeSettingsFile, isShopifyThemeWhitelistedDir} from '../utils';
+import * as utils from '../utils';
 
 export default function(program) {
   program
@@ -23,7 +23,7 @@ export default function(program) {
         return;
       }
 
-      if (!isShopifyTheme(workingDirectory)) {
+      if (!utils.isShopifyTheme(workingDirectory)) {
         console.log('');
         console.error(yellow('  The current directory doesn\'t have /layout/theme.liquid. We have to assume this isn\'t a Shopify theme'));
         console.log('');
@@ -35,7 +35,7 @@ export default function(program) {
       const configYml = join(workingDirectory, 'config.yml');
       const pkgJson = join(workingDirectory, 'package.json');
       const srcDir = join(workingDirectory, 'src');
-      const srcConfigDir = join(workingDirectory, 'src/config');
+      const configDir = join(workingDirectory, 'src/config');
       const iconsDir = join(srcDir, 'icons');
       const stylesDir = join(srcDir, 'styles');
       const scriptsDir = join(srcDir, 'scripts');
@@ -64,26 +64,25 @@ export default function(program) {
       mkdirSync(scriptsDir);
 
       if (!existsSync(pkgJson)) {
-        writePackageJsonSync(pkgJson);
+        utils.writePackageJsonSync(pkgJson);
       }
 
       function movePromiseFactory(file) {
         console.log(`  Migrating ${file} to src/...`);
-        return move(join(workingDirectory, file), join(srcDir, file));
+        return utils.move(join(workingDirectory, file), join(srcDir, file));
       }
 
       const files = readdirSync(workingDirectory);
-      const whitelistFiles = files.filter(isShopifyThemeWhitelistedDir);
+      const whitelistFiles = files.filter(utils.isShopifyThemeWhitelistedDir);
       const movePromises = whitelistFiles.map(movePromiseFactory);
 
-      function beautifyJsonPromiseFactory(file) {
-        console.log(`  Beautifying ${file}...`);
-        return beautifyJson(join(srcConfigDir, file));
+      function unminifyJsonPromiseFactory(file) {
+        return utils.unminifyJson(join(configDir, file));
       }
 
-      const configDirFiles = readdirSync(srcConfigDir);
-      const themeSettingsFiles = configDirFiles.filter(isShopifyThemeSettingsFile);
-      const beautifyPromises = themeSettingsFiles.map(beautifyJsonPromiseFactory);
+      const configDirFiles = readdirSync(configDir);
+      const themeSettingsFiles = configDirFiles.filter(utils.isShopifyThemeSettingsFile);
+      const unminifyPromises = themeSettingsFiles.map(unminifyJsonPromiseFactory);
 
       try {
         await Promise.all(movePromises);
@@ -92,20 +91,17 @@ export default function(program) {
         console.log(`  ${green(figures.tick)} Migration to src/ completed`);
         console.log('');
 
-        await Promise.all(beautifyPromises);
-
-        console.log(`  ${green(figures.tick)} Beautification of settings files completed`);
-        console.log('');
+        await Promise.all(unminifyPromises);
 
         console.log('  Installing Slate dependencies...');
         console.log('');
 
         if (options.yarn) {
-          await startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
+          await utils.startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
             cwd: workingDirectory,
           });
         } else {
-          await startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
+          await utils.startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
             cwd: workingDirectory,
           });
         }
@@ -117,7 +113,7 @@ export default function(program) {
         if (!existsSync(configYml)) {
           const configUrl = 'https://raw.githubusercontent.com/Shopify/slate//master/packages/slate-theme/config-sample.yml';
 
-          await downloadFromUrl(configUrl, join(workingDirectory, 'config.yml'));
+          await utils.downloadFromUrl(configUrl, join(workingDirectory, 'config.yml'));
 
           console.error(`  ${green(figures.tick)} Configuration file generated`);
           console.error(yellow('  Your theme was missing config.yml in the root directory. Please open and edit it before using Slate commands'));

--- a/packages/slate-cli/src/utils.js
+++ b/packages/slate-cli/src/utils.js
@@ -142,16 +142,16 @@ export function hasDependency(dependencyName, pkg) {
 
 
 /**
- * Beautify a JSON file
+ * Umminify a JSON file
  *
- * @param {string} file - The path to the file.
+ * @param {string} file - The path to the file to unminify
  */
-export function beautifyJson(file) {
+export function unminifyJson(file) {
   return new Promise((resolve, reject) => {
     try {
       const jsonString = readFileSync(file);
-      const beautifiedJsonString = JSON.stringify(JSON.parse(jsonString), null, 2);
-      writeFileSync(file, beautifiedJsonString);
+      const unminifiedJsonString = JSON.stringify(JSON.parse(jsonString), null, 2);
+      writeFileSync(file, unminifiedJsonString);
       resolve();
     } catch (err) {
       reject(err);
@@ -204,6 +204,5 @@ export function isShopifyThemeWhitelistedDir(directory) {
  * @param {string} file - The path to the file.
  */
 export function isShopifyThemeSettingsFile(file) {
-  const whitelist = ['settings_schema.json', 'settings_data.json'];
-  return whitelist.indexOf(file) > -1;
+  return /^settings_.+\.json/.test(file);
 }

--- a/packages/slate-cli/src/utils.js
+++ b/packages/slate-cli/src/utils.js
@@ -201,7 +201,7 @@ export function isShopifyThemeWhitelistedDir(directory) {
 /**
  * Tests if file is a Shopify theme settings file (settings_*.json)
  *
- * @param {string} directory - The path to the directory.
+ * @param {string} file - The path to the file.
  */
 export function isShopifyThemeSettingsFile(file) {
   const whitelist = ['settings_schema.json', 'settings_data.json'];

--- a/packages/slate-cli/src/utils.js
+++ b/packages/slate-cli/src/utils.js
@@ -1,4 +1,4 @@
-import {createReadStream, createWriteStream, rename, unlinkSync, writeFileSync, existsSync} from 'fs';
+import {createReadStream, createWriteStream, rename, unlinkSync, readFileSync, writeFileSync, existsSync} from 'fs';
 import {join, normalize} from 'path';
 import {Extract} from 'unzip2';
 import {get} from 'https';
@@ -140,6 +140,25 @@ export function hasDependency(dependencyName, pkg) {
   return hasDependencies;
 }
 
+
+/**
+ * Beautify a JSON file
+ *
+ * @param {string} file - The path to the file.
+ */
+export function beautifyJson(file) {
+  return new Promise((resolve, reject) => {
+    try {
+      const jsonString = readFileSync(file);
+      const beautifiedJsonString = JSON.stringify(JSON.parse(jsonString), null, 2);
+      writeFileSync(file, beautifiedJsonString);
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
 /**
  * Moves file from one location to another
  *
@@ -177,4 +196,14 @@ export function isShopifyTheme(directory) {
 export function isShopifyThemeWhitelistedDir(directory) {
   const whitelist = ['assets', 'layout', 'config', 'locales', 'sections', 'snippets', 'templates'];
   return whitelist.indexOf(directory) > -1;
+}
+
+/**
+ * Tests if file is a Shopify theme settings file (settings_*.json)
+ *
+ * @param {string} directory - The path to the directory.
+ */
+export function isShopifyThemeSettingsFile(file) {
+  const whitelist = ['settings_schema.json', 'settings_data.json'];
+  return whitelist.indexOf(file) > -1;
 }


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Beautify the settings files (`settings_*.json`) upon migration (fix #224).

### Expected results
The settings files are pretty printed (indented with 2 spaces).

### Checklist
For contributors:
- [X] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [X] I have :tophat:'d these changes.

