### PR TITLE
Add 'itemCondition' Schema.org meta tag http://schema.org/itemCondition

### DIFF
--- a/packages/slate-theme/src/sections/featured-product.liquid
+++ b/packages/slate-theme/src/sections/featured-product.liquid
@@ -12,6 +12,7 @@
   <meta itemprop="url" content="{{ shop.url }}{{ product.url }}">
   <meta itemprop="image" content="{{ featured_image | img_url: '800x' }}">
   <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
+  <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/NewCondition">
 
   {% if featured_image.src != blank %}
     <img src="{{ featured_image | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>

--- a/packages/slate-theme/src/sections/product.liquid
+++ b/packages/slate-theme/src/sections/product.liquid
@@ -8,6 +8,7 @@
   <meta itemprop="brand" content="{{ product.vendor }}">
   <meta itemprop="image" content="{{ featured_image | img_url: '600x600' }}">
   <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
+  <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/NewCondition">
 
   {% if featured_image != blank %}
     <img src="{{ featured_image | img_url: '480x480' }}" alt="{{ featured_image.alt | escape }}" data-product-featured-image>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Schema.org's `itemCondition` is an important (possibly mandatory) meta tag for products, proposing this be added to Slate. :tophat: @robcurry

http://schema.org/itemCondition

Issue: https://github.com/Shopify/slate/issues/348