### PR TITLE
Prefix mixin conditionals were not supporting 'all', fixed to allow

### DIFF
--- a/packages/slate-theme/src/styles/tools/mixins.scss
+++ b/packages/slate-theme/src/styles/tools/mixins.scss
@@ -31,16 +31,18 @@
   @each $prefix in $prefixes {
     @if $prefix == webkit {
       -webkit-#{$property}: $value;
-    } @else if $prefix == moz {
+    }
+    @if $prefix == moz {
       -moz-#{$property}: $value;
-    } @else if $prefix == ms {
+    }
+    @if $prefix == ms {
       -ms-#{$property}: $value;
-    } @else if $prefix == o {
+    }
+    @if $prefix == o {
       -o-#{$property}: $value;
-    } @else if $prefix == spec {
+    }
+    @if $prefix == spec {
       #{$property}: $value;
-    } @else  {
-      @warn 'Unrecognized prefix: #{$prefix}';
     }
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

The `prefix` mixin was not supporting 'all' due to the `if-else` conditionals. Switched to multiple `if` statements to fix.