### PR TITLE
Make sure we log errors on watch command

### DIFF
--- a/packages/slate-tools/src/tasks/includes/messages.js
+++ b/packages/slate-tools/src/tasks/includes/messages.js
@@ -36,7 +36,7 @@ const messages = {
 
   logTransferFailed: (errMsg) => {
     gutil.log('Transfer Failed:',
-      gutil.colors.yellow(`${typeof errMsg === 'string' ? errMsg : 'File(s) failed to upload to store. See log notes above.'}`),
+      gutil.colors.yellow(`${typeof errMsg === 'string' ? errMsg : 'File(s) failed to upload to store. See log notes in deploy.log'}`),
     );
   },
 
@@ -62,6 +62,16 @@ const messages = {
     const fileList = `${files.join(', ')}.\n`;
 
     return timestamp + action + amount + fileList;
+  },
+
+  logDeployErrors: (cmd, files, err) => {
+    const timestamp = `Deploy error @ ${new Date()}. `;
+    const action = cmd === 'upload' ? 'added/changed ' : 'removed ';
+    const amount = `${files.length} file(s): `;
+    const fileList = `${files.join(', ')}.\n`;
+    const errMsg = `${err} \n`;
+
+    return timestamp + action + amount + fileList + errMsg;
   },
 
   logBundleJs: () => {

--- a/packages/slate-tools/src/tasks/watchers.js
+++ b/packages/slate-tools/src/tasks/watchers.js
@@ -69,6 +69,7 @@ function deploy(cmd, files, env) {
   }).catch((err) => {
     activeDeploy = false;
     messages.logTransferFailed(err);
+    fs.appendFileSync(config.deployLog, messages.logDeployErrors(cmd, files, err)); // eslint-disable-line no-sync
     return checkDeployStatus();
   });
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/slate/issues/243

Its not possible to see error details if the error thrown by the Themekit child process is not a string. This makes sure that we log all watch errors in the deploy log, including those which are not strings.

