### PR TITLE
Use stylelint as a postcss plugin instead of a webpack plugin

### DIFF
--- a/packages/slate-tools/config/webpack.base.conf.js
+++ b/packages/slate-tools/config/webpack.base.conf.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const webpack = require('webpack');
-const StyleLintPlugin = require('stylelint-webpack-plugin');
 const WriteFileWebpackPlugin = require('write-file-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const config = require('../config');
@@ -85,24 +84,6 @@ const babelLoader = () => {
   ];
 };
 
-function stylelintLoader() {
-  if (!fs.existsSync(config.paths.stylelint.rc)) {
-    return [];
-  }
-
-  const ignorePath = fs.existsSync(config.paths.stylelint.ignore)
-    ? config.paths.stylelint.ignore
-    : null;
-
-  return [
-    new StyleLintPlugin({
-      configFile: config.paths.stylelint.rc,
-      emitErrors: !isDevServer,
-      ignorePath,
-    }),
-  ];
-}
-
 module.exports = {
   context: paths.src,
 
@@ -178,8 +159,6 @@ module.exports = {
 
   plugins: [
     ...contextReplacementPlugins(),
-
-    ...stylelintLoader(),
 
     new CopyWebpackPlugin([
       {

--- a/packages/slate-tools/config/webpack.dev.conf.js
+++ b/packages/slate-tools/config/webpack.dev.conf.js
@@ -3,6 +3,8 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const autoprefixer = require('autoprefixer');
+const postcssReporter = require('postcss-reporter');
+const stylelint = require('../lib/postcss-stylelint');
 const webpackConfig = require('./webpack.base.conf');
 const commonExcludes = require('../lib/common-excludes');
 const userWebpackConfig = require('../lib/get-user-webpack-config')('dev');
@@ -29,6 +31,7 @@ module.exports = merge(
           test: /\.s[ac]ss$/,
           exclude: commonExcludes(),
           use: [
+            ...stylelint(),
             'style-loader',
             {
               loader: 'css-loader',
@@ -36,7 +39,13 @@ module.exports = merge(
             },
             {
               loader: 'postcss-loader',
-              options: {plugins: [autoprefixer]},
+              options: {
+                plugins: [
+                  autoprefixer,
+                  ...stylelint(),
+                  postcssReporter({clearReportedMessages: true}),
+                ],
+              },
             },
             'sass-loader',
           ],

--- a/packages/slate-tools/config/webpack.prod.conf.js
+++ b/packages/slate-tools/config/webpack.prod.conf.js
@@ -6,6 +6,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
+const postcssReporter = require('postcss-reporter');
+const stylelint = require('../lib/postcss-stylelint');
 const webpackConfig = require('./webpack.base.conf');
 const commonExcludes = require('../lib/common-excludes');
 const userWebpackConfig = require('../lib/get-user-webpack-config')('prod');
@@ -32,7 +34,14 @@ module.exports = merge(
               },
               {
                 loader: 'postcss-loader',
-                options: {plugins: [autoprefixer, cssnano]},
+                options: {
+                  plugins: [
+                    autoprefixer,
+                    cssnano,
+                    ...stylelint(),
+                    postcssReporter({clearReportedMessages: true, throwError: true}),
+                  ],
+                },
               },
               'sass-loader',
             ],

--- a/packages/slate-tools/lib/postcss-stylelint.js
+++ b/packages/slate-tools/lib/postcss-stylelint.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const StyleLint = require('stylelint');
+const config = require('../config');
+
+function stylelint() {
+  if (!fs.existsSync(config.paths.stylelint.rc)) {
+    return [];
+  }
+
+  const ignorePath = fs.existsSync(config.paths.stylelint.ignore)
+    ? config.paths.stylelint.ignore
+    : null;
+
+  return [
+    new StyleLint({
+      configFile: config.paths.stylelint.rc,
+      ignorePath,
+    }),
+  ];
+}
+
+module.exports = stylelint;

--- a/packages/slate-tools/package-lock.json
+++ b/packages/slate-tools/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "@shopify/slate-tools",
+	"version": "1.0.0-alpha.9",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@shopify/themekit": {
 			"version": "0.6.11",
@@ -50,6 +52,21 @@
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
 			"requires": {
 				"acorn": "4.0.13"
+			}
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+				}
 			}
 		},
 		"ajv": {
@@ -221,11 +238,6 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -393,122 +405,6 @@
 				"trim-right": "1.0.1"
 			}
 		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-define-map": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-optimise-call-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-replace-supers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -546,14 +442,6 @@
 				"babel-runtime": "6.26.0"
 			}
 		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
@@ -579,270 +467,6 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
 			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
 		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-arrow-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoped-functions": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-block-scoping": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
-			}
-		},
-		"babel-plugin-transform-es2015-classes": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-computed-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-duplicate-keys": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-for-of": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-amd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-systemjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-umd": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-object-super": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-shorthand-properties": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-template-literals": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-typeof-symbol": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-regenerator": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"requires": {
-				"regenerator-transform": "0.10.1"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
 		"babel-polyfill": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -858,42 +482,6 @@
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
 					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 				}
-			}
-		},
-		"babel-preset-env": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.4.0.tgz",
-			"integrity": "sha1-yOAqO8x3kvI83taOA1W51MKPD3o=",
-			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0",
-				"browserslist": "1.7.7",
-				"invariant": "2.2.2"
 			}
 		},
 		"babel-preset-jest": {
@@ -1212,11 +800,11 @@
 			}
 		},
 		"browserify-zlib": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -1276,6 +864,64 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+		},
+		"cacache": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+			"integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.1",
+				"mississippi": "1.3.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.0.0",
+				"unique-filename": "1.1.0",
+				"y18n": "3.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"requires": {
+						"glob": "7.1.2"
+					}
+				}
+			}
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"requires": {
+				"callsites": "0.2.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+					"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+				}
+			}
 		},
 		"callsites": {
 			"version": "2.0.0",
@@ -1375,13 +1021,10 @@
 				"supports-color": "2.0.0"
 			}
 		},
-		"character-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-			"integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-			"requires": {
-				"is-regex": "1.0.4"
-			}
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"chokidar": {
 			"version": "1.7.0",
@@ -1421,6 +1064,11 @@
 					}
 				}
 			}
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"ci-info": {
 			"version": "1.1.1",
@@ -1464,6 +1112,19 @@
 			"requires": {
 				"rimraf": "2.5.4"
 			}
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
@@ -1631,22 +1292,6 @@
 			"resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
 			"integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ="
 		},
-		"constantinople": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz",
-			"integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
-			"requires": {
-				"acorn": "3.3.0",
-				"is-expression": "2.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-				}
-			}
-		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -1686,6 +1331,114 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.5.4",
+				"run-queue": "1.0.3"
+			}
+		},
+		"copy-webpack-plugin": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
+			"integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
+			"requires": {
+				"cacache": "10.0.1",
+				"find-cache-dir": "1.0.0",
+				"globby": "7.1.1",
+				"is-glob": "4.0.0",
+				"loader-utils": "0.2.17",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"p-limit": "1.1.0",
+				"pify": "3.0.0",
+				"serialize-javascript": "1.4.0"
+			},
+			"dependencies": {
+				"find-cache-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+					"requires": {
+						"commondir": "1.0.1",
+						"make-dir": "1.1.0",
+						"pkg-dir": "2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"glob": "7.1.2",
+						"ignore": "3.3.7",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
+					}
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "2.1.0"
+					}
+				}
+			}
 		},
 		"core-js": {
 			"version": "2.5.1",
@@ -1933,6 +1686,19 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
 				"array-find-index": "1.0.2"
+			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"requires": {
+				"es5-ext": "0.10.37"
 			}
 		},
 		"dashdash": {
@@ -2227,6 +1993,30 @@
 				"randombytes": "2.0.5"
 			}
 		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
 		"doctrine": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -2235,11 +2025,6 @@
 				"esutils": "2.0.2",
 				"isarray": "1.0.0"
 			}
-		},
-		"doctypes": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-			"integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
 		},
 		"dom-converter": {
 			"version": "0.1.4",
@@ -2437,6 +2222,70 @@
 				"is-arrayish": "0.2.1"
 			}
 		},
+		"es5-ext": {
+			"version": "0.10.37",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+			"integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2463,6 +2312,171 @@
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				}
+			}
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
+			"integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
+			"requires": {
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.0",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.0.2",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.2",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.1.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.0.1",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.4.1",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "4.6.0",
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+					"integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+					"requires": {
+						"esutils": "2.0.2"
+					}
+				},
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"globals": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+					"integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ=="
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"js-yaml": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+					"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+					"requires": {
+						"argparse": "1.0.9",
+						"esprima": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
 				}
 			}
 		},
@@ -2538,10 +2552,57 @@
 				"pkg-up": "1.0.0"
 			}
 		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"requires": {
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+		},
+		"espree": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+			"integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+			"requires": {
+				"acorn": "5.3.0",
+				"acorn-jsx": "3.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+					"integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+				}
+			}
+		},
 		"esprima": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
 			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
 		},
 		"estraverse": {
 			"version": "4.2.0",
@@ -2557,6 +2618,15 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37"
+			}
 		},
 		"events": {
 			"version": "1.1.1",
@@ -2718,6 +2788,16 @@
 			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 			"requires": {
 				"is-extendable": "0.1.1"
+			}
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2982,6 +3062,15 @@
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
+		"flush-write-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3020,6 +3109,15 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
 			"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
 		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
+		},
 		"fs-extra": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -3034,6 +3132,17 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
 			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -3841,6 +3950,11 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -4517,9 +4631,9 @@
 			}
 		},
 		"https-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-			"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"iconv-lite": {
 			"version": "0.4.19",
@@ -4535,6 +4649,11 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
 			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.7",
@@ -4676,10 +4795,104 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
 			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
 		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"requires": {
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.0",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+					"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"requires": {
+						"escape-string-regexp": "1.0.5"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
 		"interpret": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-			"integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"invariant": {
 			"version": "2.2.2",
@@ -4772,22 +4985,6 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
 				"is-primitive": "2.0.0"
-			}
-		},
-		"is-expression": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz",
-			"integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
-			"requires": {
-				"acorn": "3.3.0",
-				"object-assign": "4.1.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-				}
 			}
 		},
 		"is-extendable": {
@@ -4923,14 +5120,6 @@
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
-		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"requires": {
-				"has": "1.0.1"
-			}
-		},
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -4940,6 +5129,11 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
 			"integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
+		},
+		"is-resolvable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+			"integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
@@ -5412,11 +5606,6 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
 			"integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
 		},
-		"js-stringify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-			"integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -5491,6 +5680,11 @@
 				"jsonify": "0.0.0"
 			}
 		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -5528,15 +5722,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jstransformer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-			"integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-			"requires": {
-				"is-promise": "2.1.0",
-				"promise": "7.3.1"
 			}
 		},
 		"kind-of": {
@@ -5967,6 +6152,14 @@
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.1.0"
+			}
+		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -6078,6 +6271,11 @@
 				"mime-db": "1.30.0"
 			}
 		},
+		"mimic-fn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -6100,6 +6298,34 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"mississippi": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+			"integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+			"requires": {
+				"concat-stream": "1.6.0",
+				"duplexify": "3.5.1",
+				"end-of-stream": "1.4.0",
+				"flush-write-stream": "1.0.2",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "1.0.3",
+				"pumpify": "1.3.5",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
 		},
 		"mixin-object": {
 			"version": "2.0.1",
@@ -6136,6 +6362,19 @@
 			"version": "2.19.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
 			"integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.5.4",
+				"run-queue": "1.0.3"
+			}
 		},
 		"mozjpeg": {
 			"version": "4.1.1",
@@ -6190,6 +6429,11 @@
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.7.0",
@@ -6268,20 +6512,20 @@
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"requires": {
 				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
+				"browserify-zlib": "0.2.0",
 				"buffer": "4.9.1",
 				"console-browserify": "1.1.0",
 				"constants-browserify": "1.0.0",
 				"crypto-browserify": "3.12.0",
 				"domain-browser": "1.1.7",
 				"events": "1.1.1",
-				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
 				"process": "0.11.10",
 				"punycode": "1.4.1",
@@ -6289,19 +6533,12 @@
 				"readable-stream": "2.3.3",
 				"stream-browserify": "2.0.1",
 				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
+				"string_decoder": "1.0.3",
 				"timers-browserify": "2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "0.11.0",
 				"util": "0.10.3",
 				"vm-browserify": "0.0.4"
-			},
-			"dependencies": {
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
 			}
 		},
 		"node-notifier": {
@@ -6588,9 +6825,9 @@
 			}
 		},
 		"os-browserify": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-			"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-filter-obj": {
 			"version": "1.0.3",
@@ -6663,9 +6900,19 @@
 			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
 		},
 		"pako": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			}
 		},
 		"param-case": {
 			"version": "2.1.1",
@@ -6839,6 +7086,11 @@
 			"requires": {
 				"find-up": "1.1.2"
 			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
 		},
 		"pngquant-bin": {
 			"version": "3.1.1",
@@ -7417,7 +7669,7 @@
 				"chalk": "2.3.0",
 				"lodash": "4.17.4",
 				"log-symbols": "2.1.0",
-				"postcss": "6.0.14"
+				"postcss": "6.0.15"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7444,13 +7696,23 @@
 					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				},
 				"postcss": {
-					"version": "6.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-					"integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+					"version": "6.0.15",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+					"integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
 					"requires": {
 						"chalk": "2.3.0",
 						"source-map": "0.6.1",
-						"supports-color": "4.5.0"
+						"supports-color": "5.1.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+							"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+							"requires": {
+								"has-flag": "2.0.0"
+							}
+						}
 					}
 				},
 				"source-map": {
@@ -7689,13 +7951,15 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
 			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "2.0.6"
-			}
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"proxy-addr": {
 			"version": "1.1.5",
@@ -7728,182 +7992,24 @@
 				"randombytes": "2.0.5"
 			}
 		},
-		"pug": {
-			"version": "2.0.0-beta6",
-			"resolved": "https://registry.npmjs.org/pug/-/pug-2.0.0-beta6.tgz",
-			"integrity": "sha1-nq0uWeVApGfvw3h8ywPkV0ul+uk=",
+		"pump": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
 			"requires": {
-				"pug-code-gen": "1.1.1",
-				"pug-filters": "1.2.4",
-				"pug-lexer": "2.3.2",
-				"pug-linker": "1.0.2",
-				"pug-load": "2.0.9",
-				"pug-parser": "2.0.2",
-				"pug-runtime": "2.0.3",
-				"pug-strip-comments": "1.0.2"
+				"end-of-stream": "1.4.0",
+				"once": "1.4.0"
 			}
 		},
-		"pug-attrs": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.2.tgz",
-			"integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
+		"pumpify": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+			"integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
 			"requires": {
-				"constantinople": "3.1.0",
-				"js-stringify": "1.0.2",
-				"pug-runtime": "2.0.3"
+				"duplexify": "3.5.1",
+				"inherits": "2.0.3",
+				"pump": "1.0.3"
 			}
-		},
-		"pug-code-gen": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-1.1.1.tgz",
-			"integrity": "sha1-HPcnRO8qA56uajNAyqoRBYcSWOg=",
-			"requires": {
-				"constantinople": "3.1.0",
-				"doctypes": "1.1.0",
-				"js-stringify": "1.0.2",
-				"pug-attrs": "2.0.2",
-				"pug-error": "1.3.2",
-				"pug-runtime": "2.0.3",
-				"void-elements": "2.0.1",
-				"with": "5.1.1"
-			}
-		},
-		"pug-error": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
-			"integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY="
-		},
-		"pug-filters": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-1.2.4.tgz",
-			"integrity": "sha1-kthSRyx0UIVyoNmwyR+dy5rgWDk=",
-			"requires": {
-				"clean-css": "3.4.28",
-				"constantinople": "3.1.0",
-				"jstransformer": "1.0.0",
-				"pug-error": "1.3.2",
-				"pug-walk": "1.1.5",
-				"resolve": "1.5.0",
-				"uglify-js": "2.8.29"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-				},
-				"clean-css": {
-					"version": "3.4.28",
-					"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-					"integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
-					"requires": {
-						"commander": "2.8.1",
-						"source-map": "0.4.4"
-					}
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": "1.0.1"
-					}
-				},
-				"uglify-js": {
-					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
-					}
-				},
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
-						"window-size": "0.1.0"
-					}
-				}
-			}
-		},
-		"pug-lexer": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-2.3.2.tgz",
-			"integrity": "sha1-aLGdlupdwOSoYUiwHLlmwXgVphQ=",
-			"requires": {
-				"character-parser": "2.2.0",
-				"is-expression": "3.0.0",
-				"pug-error": "1.3.2"
-			},
-			"dependencies": {
-				"is-expression": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-					"integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-					"requires": {
-						"acorn": "4.0.13",
-						"object-assign": "4.1.1"
-					}
-				}
-			}
-		},
-		"pug-linker": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-1.0.2.tgz",
-			"integrity": "sha1-yjXdF+UO3nzCXM3FNKD9aPCJB1w=",
-			"requires": {
-				"pug-error": "1.3.2",
-				"pug-walk": "1.1.5"
-			}
-		},
-		"pug-load": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.9.tgz",
-			"integrity": "sha512-BDdZOCru4mg+1MiZwRQZh25+NTRo/R6/qArrdWIf308rHtWA5N9kpoUskRe4H6FslaQujC+DigH9LqlBA4gf6Q==",
-			"requires": {
-				"object-assign": "4.1.1",
-				"pug-walk": "1.1.5"
-			}
-		},
-		"pug-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-2.0.2.tgz",
-			"integrity": "sha1-U6aAz9BQOdywwn0CkJS8SnkmibA=",
-			"requires": {
-				"pug-error": "1.3.2",
-				"token-stream": "0.0.1"
-			}
-		},
-		"pug-runtime": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.3.tgz",
-			"integrity": "sha1-mBYmB7D86eJU1CfzOYelrucWi9o="
-		},
-		"pug-strip-comments": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.2.tgz",
-			"integrity": "sha1-0xOvoBvMN0mA4TmeI+vy65vchRM=",
-			"requires": {
-				"pug-error": "1.3.2"
-			}
-		},
-		"pug-walk": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.5.tgz",
-			"integrity": "sha512-rJlH1lXerCIAtImXBze3dtKq/ykZMA4rpO9FnPcIgsWcxZLOvd8zltaoeOVFyBSSqCkhhJWbEbTMga8UxWUUSA=="
 		},
 		"punycode": {
 			"version": "1.4.1",
@@ -8163,32 +8269,12 @@
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
 			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
 		},
-		"regenerator-transform": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
-			}
-		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
 				"is-equal-shallow": "0.1.3"
-			}
-		},
-		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -8327,6 +8413,22 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+				}
+			}
+		},
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -8344,6 +8446,25 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			},
+			"dependencies": {
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"requires": {
+						"mimic-fn": "1.1.0"
+					}
+				}
+			}
 		},
 		"right-align": {
 			"version": "0.1.3",
@@ -8383,6 +8504,35 @@
 			"requires": {
 				"hash-base": "2.0.2",
 				"inherits": "2.0.3"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"requires": {
+				"aproba": "1.2.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"requires": {
+				"rx-lite": "4.0.8"
 			}
 		},
 		"safe-buffer": {
@@ -8598,6 +8748,11 @@
 					}
 				}
 			}
+		},
+		"serialize-javascript": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+			"integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
 		},
 		"serve-static": {
 			"version": "1.12.3",
@@ -8821,6 +8976,14 @@
 				"tweetnacl": "0.14.5"
 			}
 		},
+		"ssri": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+			"integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"stat-mode": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
@@ -8855,6 +9018,15 @@
 			"requires": {
 				"duplexer2": "0.1.4",
 				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"requires": {
+				"end-of-stream": "1.4.0",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
@@ -9436,10 +9608,20 @@
 				"require-main-filename": "1.0.1"
 			}
 		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
 		"throat": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
 			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "0.6.5",
@@ -9511,6 +9693,14 @@
 				"setimmediate": "1.0.5"
 			}
 		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -9533,11 +9723,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-		},
-		"token-stream": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-			"integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
 		},
 		"toposort": {
 			"version": "1.0.6",
@@ -9640,6 +9825,91 @@
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
 			"optional": true
 		},
+		"uglifyjs-webpack-plugin": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
+			"integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
+			"requires": {
+				"cacache": "10.0.1",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.4.2",
+				"serialize-javascript": "1.4.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.4",
+				"webpack-sources": "1.1.0",
+				"worker-farm": "1.5.2"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.12.2",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+					"integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+				},
+				"find-cache-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+					"requires": {
+						"commondir": "1.0.1",
+						"make-dir": "1.1.0",
+						"pkg-dir": "2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "2.1.0"
+					}
+				},
+				"source-list-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"uglify-es": {
+					"version": "3.3.4",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.4.tgz",
+					"integrity": "sha512-vDOyDaf7LcABZI5oJt8bin5FD8kYONux5jd8FY6SsV2SfD+MMXaPeGUotysbycSxdu170y5IQ8FvlKzU/TUryw==",
+					"requires": {
+						"commander": "2.12.2",
+						"source-map": "0.6.1"
+					}
+				},
+				"webpack-sources": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+					"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+					"requires": {
+						"source-list-map": "2.0.0",
+						"source-map": "0.6.1"
+					}
+				},
+				"worker-farm": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+					"integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+					"requires": {
+						"errno": "0.1.4",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -9657,6 +9927,22 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
 		},
 		"unique-stream": {
 			"version": "2.2.1",
@@ -9879,11 +10165,6 @@
 				"indexof": "0.0.1"
 			}
 		},
-		"void-elements": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
-		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -9921,70 +10202,166 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz",
-			"integrity": "sha1-YXQvDPivVVuHRgqc2Lui8ePuL84=",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+			"integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
 			"requires": {
-				"acorn": "5.2.1",
+				"acorn": "5.3.0",
 				"acorn-dynamic-import": "2.0.2",
-				"ajv": "4.11.8",
-				"ajv-keywords": "1.5.1",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
 				"async": "2.6.0",
 				"enhanced-resolve": "3.4.1",
-				"interpret": "1.0.4",
+				"escope": "3.6.0",
+				"interpret": "1.1.0",
 				"json-loader": "0.5.7",
 				"json5": "0.5.1",
 				"loader-runner": "2.3.0",
-				"loader-utils": "0.2.17",
+				"loader-utils": "1.1.0",
 				"memory-fs": "0.4.1",
 				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
+				"node-libs-browser": "2.1.0",
 				"source-map": "0.5.7",
-				"supports-color": "3.2.3",
+				"supports-color": "4.5.0",
 				"tapable": "0.2.8",
-				"uglify-js": "2.8.29",
+				"uglifyjs-webpack-plugin": "0.4.6",
 				"watchpack": "1.4.0",
-				"webpack-sources": "0.2.3",
-				"yargs": "6.6.0"
+				"webpack-sources": "1.1.0",
+				"yargs": "8.0.2"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-					"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+					"integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
 				},
-				"ajv-keywords": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "4.6.0",
+						"fast-deep-equal": "1.0.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"camelcase": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
 				},
-				"loader-utils": {
-					"version": "0.2.17",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"locate-path": "2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"source-list-map": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
-					"integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE="
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+					"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "2.0.0"
 					}
 				},
 				"uglify-js": {
@@ -10010,39 +10387,61 @@
 						}
 					}
 				},
-				"webpack-sources": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
-					"integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+				"uglifyjs-webpack-plugin": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
 					"requires": {
-						"source-list-map": "1.1.2",
-						"source-map": "0.5.7"
+						"source-map": "0.5.7",
+						"uglify-js": "2.8.29",
+						"webpack-sources": "1.1.0"
 					}
 				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+				"webpack-sources": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+					"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 					"requires": {
-						"camelcase": "3.0.0",
+						"source-list-map": "2.0.0",
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						}
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "4.1.0",
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
 						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
 						"require-directory": "2.1.1",
 						"require-main-filename": "1.0.1",
 						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"yargs-parser": "7.0.0"
 					},
 					"dependencies": {
 						"camelcase": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 						},
 						"cliui": {
 							"version": "3.2.0",
@@ -10052,22 +10451,34 @@
 								"string-width": "1.0.2",
 								"strip-ansi": "3.0.1",
 								"wrap-ansi": "2.1.0"
+							},
+							"dependencies": {
+								"string-width": {
+									"version": "1.0.2",
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									}
+								}
 							}
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 						}
 					}
 				}
@@ -10117,87 +10528,6 @@
 			"requires": {
 				"source-list-map": "0.1.8",
 				"source-map": "0.5.7"
-			}
-		},
-		"webpack-svgstore-plugin": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/webpack-svgstore-plugin/-/webpack-svgstore-plugin-4.0.0.tgz",
-			"integrity": "sha1-sUE778qOoG9tI+CT2Pds+anv18c=",
-			"requires": {
-				"async": "2.1.4",
-				"globby": "6.1.0",
-				"htmlparser2": "3.9.2",
-				"lodash": "4.17.2",
-				"pug": "2.0.0-beta6",
-				"svgo": "0.7.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-					"integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-					"requires": {
-						"lodash": "4.17.2"
-					}
-				},
-				"csso": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/csso/-/csso-2.2.1.tgz",
-					"integrity": "sha1-Ufu1NH5Q6B5u1RZopISQrm/ir+I=",
-					"requires": {
-						"clap": "1.2.3",
-						"source-map": "0.5.7"
-					}
-				},
-				"domhandler": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-					"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-					"requires": {
-						"domelementtype": "1.3.0"
-					}
-				},
-				"htmlparser2": {
-					"version": "3.9.2",
-					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-					"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-					"requires": {
-						"domelementtype": "1.3.0",
-						"domhandler": "2.4.1",
-						"domutils": "1.5.1",
-						"entities": "1.1.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.3"
-					}
-				},
-				"js-yaml": {
-					"version": "3.6.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-					"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
-					}
-				},
-				"lodash": {
-					"version": "4.17.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-					"integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I="
-				},
-				"svgo": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.1.tgz",
-					"integrity": "sha1-KHMg/tlyywl+csK7FoX5b+CPgDQ=",
-					"requires": {
-						"coa": "1.0.4",
-						"colors": "1.1.2",
-						"csso": "2.2.1",
-						"js-yaml": "3.6.1",
-						"mkdirp": "0.5.1",
-						"sax": "1.2.4",
-						"whet.extend": "0.9.9"
-					}
-				}
 			}
 		},
 		"websocket-driver": {
@@ -10268,22 +10598,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-		},
-		"with": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-			"integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
-			"requires": {
-				"acorn": "3.3.0",
-				"acorn-globals": "3.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-				}
-			}
 		},
 		"wordwrap": {
 			"version": "0.0.3",

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -43,6 +43,7 @@
     "minimist": "1.2.0",
     "node-sass": "4.5.3",
     "postcss-loader": "2.0.5",
+    "postcss-reporter": "^5.0.0",
     "raw-loader": "^0.5.1",
     "react-dev-utils": "0.5.2",
     "sass-loader": "6.0.5",


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Use `stylelint` as a `postcss` plugin instead of a webpack plugin. Also added `postcss-reporter` plugin to properly report `stylelint` warnings / errors. 

This change will facilitate extra manipulations to the stylesheets.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

