### PR TITLE
Change slate-common-excludes webpackCommonExcludes config type to obj…

### DIFF
--- a/packages/slate-common-excludes/config.js
+++ b/packages/slate-common-excludes/config.js
@@ -6,7 +6,7 @@ module.exports = slateConfig.generate({
       id: 'webpackCommonExcludes',
       default: ['node_modules', 'assets/vendors/'],
       description: 'Paths to exclude for all webpack loaders',
-      type: 'array',
+      type: 'object',
     },
   ],
 });


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

This PR changes the type for the `webpackCommonExcludes` setting in the `slate-common-excludes` package's config schema from `array` to `object`. This is necessary because `slate-config` evaluates types using `typeof` which will evaluate `typeof []` to an `object` and not an `array`. Therefore, when setting the config in a theme's `.slaterc` file, `slate-config` fails with a validation error. 

https://github.com/Shopify/slate/blob/419f87d492db7bdfac4431dfdd96db2fdb51dd1c/packages/slate-config/validate.js#L19-L40

Another approach would be to change how we evaluate types in `slate-config` to use a more thorough system.

### Checklist
For maintainers:
- [x] I have :tophat:'d these changes.

