### PR TITLE
Add support for type array in slate config

### DIFF
--- a/packages/slate-config/__tests__/fixtures/schema.js
+++ b/packages/slate-config/__tests__/fixtures/schema.js
@@ -5,5 +5,10 @@ module.exports = {
       default: 'default-value',
       type: 'string',
     },
+    {
+      id: 'test-array',
+      default: ['item1', 'item2'],
+      type: 'array',
+    },
   ],
 };

--- a/packages/slate-config/__tests__/validate.test.js
+++ b/packages/slate-config/__tests__/validate.test.js
@@ -11,6 +11,15 @@ describe('validate()', () => {
 
   describe('checks .slaterc with the following tests', () => {
     describe('test: isValidType', () => {
+      test('validates item of type array when read from json', () => {
+        const json = '{"test-array": ["item1", "item2", "item3"]}';
+        const slatercWithArray = JSON.parse(json);
+
+        const results = validate(schema, slatercWithArray);
+        expect(results).toHaveProperty('isValid');
+        expect(results.isValid).toEqual(true);
+      });
+
       test('returns error if invalid type is provided', () => {
         const invalidSlateRc = Object.assign({}, slaterc, {
           'test-item': [],

--- a/packages/slate-config/validate.js
+++ b/packages/slate-config/validate.js
@@ -16,6 +16,14 @@ function validate(schema, slaterc) {
   };
 }
 
+function extractType(item, value) {
+  if (item.type === `array` && Array.isArray(value)) {
+    return item.type;
+  }
+
+  return typeof value;
+}
+
 function isValidType(schema, slaterc) {
   const errors = [];
   const warnings = [];
@@ -23,7 +31,7 @@ function isValidType(schema, slaterc) {
   schema.items.forEach(item => {
     const key = item.id;
     const value = slaterc[key];
-    const type = typeof value;
+    const type = extractType(item, value);
 
     if (type !== 'undefined') {
       if (type !== item.type) {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Add support for type `array` in the `slate-config` package. Also added an `extractType` function so that we can easily extend the types supported by `slate-config`

### How is this accomplished
Add specific check for type `array` in `slate-config` schema validation.

### Checklist

For maintainers:
- [x] I have :tophat:'d these changes.

