### PR TITLE
Add helpful comments to generated `.env` file

### DIFF
--- a/packages/slate-config/__tests__/index.test.js
+++ b/packages/slate-config/__tests__/index.test.js
@@ -20,5 +20,12 @@ describe('.generate()', () => {
         'override-value',
       );
     });
+
+    test('with the schema used to generate the config', () => {
+      const config = slateConfig.generate(schema);
+
+      expect(config).toHaveProperty('__schema');
+      expect(config.__schema).toEqual(schema);
+    })
   });
 });

--- a/packages/slate-config/index.js
+++ b/packages/slate-config/index.js
@@ -39,6 +39,8 @@ function generate(schema, slaterc = getSlateConfig()) {
     }
   });
 
+  config.__schema = schema;
+
   return config;
 }
 

--- a/packages/slate-env/README.md
+++ b/packages/slate-env/README.md
@@ -15,14 +15,14 @@ will look for a `.env.production` file.
 ## Default .env file format
 
 ```bash
+# The myshopify.com URL to your Shopify store
+SLATE_STORE=
+
 # The API password generated from a Private App
 SLATE_PASSWORD=
 
-# The ID of the theme you wish to upload files too.
+# The ID of the theme you wish to upload files too
 SLATE_THEME_ID=
-
-# The myshopify.com URL to your Shopify store.
-SLATE_STORE=
 
 # A list of file patterns to ignore, with each list item seperated by ':'
 SLATE_IGNORE_FILES=

--- a/packages/slate-env/index.js
+++ b/packages/slate-env/index.js
@@ -13,8 +13,17 @@ const SLATE_ENV_VARS = [
   config.envIgnoreFilesVar,
 ];
 
+const SLATE_ENV_VARS_DESCRIPTIONS = {
+  [config.envStoreVar]: "The myshopify.com URL to your Shopify store",
+  [config.envPasswordVar]: "The API password generated from a Private App",
+  [config.envThemeIdVar]: "The ID of the theme you wish to upload files too",
+  [config.envIgnoreFilesVar]: "A list of file patterns to ignore, with each list item seperated by ':'"
+}
+
+
+
 // Creates a new env file with optional name and values
-function create({values, name, root} = {}) {
+function create({ values, name, root } = {}) {
   const envName = _getFileName(name);
   const envPath = path.resolve(root || config.envRootDir, envName);
   const envContents = _getFileContents(values);
@@ -44,15 +53,30 @@ function _getFileContents(values) {
   }
 
   return Object.entries(env)
-    .map(keyValues => keyValues.join('='))
-    .join('\r\n');
+    .map(keyValues => {
+      let descriptionKey = '';
+      const envVar = keyValues[0];
+
+      // Search through config for the key which has a value of the env variable
+      // e.g. find the key which has the value of 'SLATE_STORE'
+      for (const key in config) {
+        if (config.hasOwnProperty(key) && config[key] === envVar) {
+          // Once we find the key, we can search the config.__schema for the
+          // schema item. We need to schema item so we can print the description
+          // comment.
+          const schemaItem = config.__schema.items.find(item => item.id === key);
+          return `# ${schemaItem.description || ''} \r\n${keyValues.join('=')}`;
+        }
+      }
+    })
+    .join('\r\n\r\n');
 }
 
 // Reads an .env file and assigns their values to environment variables
 function assign(name) {
   const envFileName = _getFileName(name);
   const envPath = path.resolve(config.envRootDir, envFileName);
-  const result = dotenv.config({path: envPath});
+  const result = dotenv.config({ path: envPath });
 
   if (typeof name !== 'undefined' && result.error) {
     throw result.error;
@@ -136,7 +160,7 @@ function _validateThemeId() {
     errors.push(
       new Error(
         `${
-          config.envThemeIdVar
+        config.envThemeIdVar
         } can be set to 'live' or a valid theme ID containing only numbers`,
       ),
     );
@@ -148,12 +172,7 @@ function _validateThemeId() {
 // Clears the values of environment variables used by Slate
 function clear() {
   const env = getEmptySlateEnv();
-
-  for (const key in env) {
-    if (env.hasOwnProperty(key)) {
-      process.env[key] = '';
-    }
-  }
+  SLATE_ENV_VARS.forEach(key => process.env[key] = '');
 }
 
 // Get the values of Slate's required environment variables

--- a/packages/slate-env/slate-env.config.js
+++ b/packages/slate-env/slate-env.config.js
@@ -36,27 +36,27 @@ module.exports = slateConfig.generate({
     {
       id: 'envStoreVar',
       default: 'SLATE_STORE',
-      description: 'The environment variable used to reference the store URL',
+      description: 'The myshopify.com URL to your Shopify store',
       type: 'string',
     },
     {
       id: 'envPasswordVar',
       default: 'SLATE_PASSWORD',
       description:
-        'The environment variable used to reference the store API password',
+        'The API password generated from a Private App',
       type: 'string',
     },
     {
       id: 'envThemeIdVar',
       default: 'SLATE_THEME_ID',
-      description: 'The environment variable used to reference the store URL',
+      description: 'The ID of the theme you wish to upload files too',
       type: 'string',
     },
     {
       id: 'envIgnoreFilesVar',
       default: 'SLATE_IGNORE_FILES',
       description:
-        'The environment variable used to reference a list of files, seperated by ":", to ignore',
+        'A list of file patterns to ignore, with each list item seperated by \':\'',
       type: 'string',
     },
   ],


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #398. Generates the following `.env` file:

```bash
# The myshopify.com URL to your Shopify store
SLATE_STORE=

# The API password generated from a Private App
SLATE_PASSWORD=

# The ID of the theme you wish to upload files too
SLATE_THEME_ID=

# A list of file patterns to ignore, with each list item seperated by ':'
SLATE_IGNORE_FILES=
```

