### PR TITLE
Add lint and format command

### DIFF
--- a/packages/slate-tools/README.md
+++ b/packages/slate-tools/README.md
@@ -47,6 +47,20 @@ Here are the available API commands for Slate:
 
 * Zips the contents of `dist` to a archive in the root folder.
 
+`lint [--scripts] [--styles] [--locales]`
+
+* Lint script, styles, and locales files for errors. [ESLint](https://eslint.org/) is used for JS files and can be configured via an `.eslintrc` file in the root folder of your theme. [Stylelint](https://stylelint.io/) is used for SCSS, SASS, and CSS files and can be configured via `.stylelintrc` file in the root folder of your theme. [Theme Lint](https://github.com/Shopify/theme-lint) is used for linting locales files.
+* (Optional) You can pass it a `--scripts` flag to only lint script files.
+* (Optional) You can pass it a `--styles` flag to only lint styles files.
+* (Optional) You can pass it a `--locales` flag to only lint locales files.
+
+`format [--scripts] [--styles] [--json]`
+
+* Formats your theme code according to the rules declared in your `.eslintrc` and `.stylelintrc` files. Uses [ESLint Fix](https://eslint.org/docs/user-guide/command-line-interface#--fix) to format JS files. Uses [Stylelint Fix](https://stylelint.io/user-guide/faq/#how-do-i-automatically-fix-stylistic-violations) to format SCSS, SASS, and CSS files. Uses [Prettier](https://github.com/prettier/prettier) to format JSON files.
+* (Optional) You can pass it a `--scripts` flag to only format script files.
+* (Optional) You can pass it a `--styles` flag to only format styles files.
+* (Optional) You can pass it a `--json` flag to only format json files.
+
 ## Caveats
 
 ### How to prevent Webpack from parsing some liquid methods and filters

--- a/packages/slate-tools/cli/commands/format.js
+++ b/packages/slate-tools/cli/commands/format.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const argv = require('yargs').argv;
+
+const {runEslintFix} = require('../../tools/eslint');
+const {runStylelintFix} = require('../../tools/stylelint');
+const {runPrettierJson} = require('../../tools/prettier');
+const config = require('../../slate-tools.config');
+
+const {scripts, styles, json} = argv;
+const runAll =
+  typeof scripts === 'undefined' &&
+  typeof styles === 'undefined' &&
+  typeof json === 'undefined';
+
+if (scripts || runAll) {
+  runEslintFix();
+}
+
+if (styles || runAll) {
+  runStylelintFix();
+}
+
+if (json || runAll) {
+  runPrettierJson();
+}

--- a/packages/slate-tools/cli/commands/lint.js
+++ b/packages/slate-tools/cli/commands/lint.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const argv = require('yargs').argv;
+
+const {runEslint} = require('../../tools/eslint');
+const {runStylelint} = require('../../tools/stylelint');
+const {runThemelint} = require('../../tools/theme-lint');
+const config = require('../../slate-tools.config');
+
+const {scripts, styles, locales} = argv;
+const runAll =
+  typeof scripts === 'undefined' &&
+  typeof styles === 'undefined' &&
+  typeof locales === 'undefined';
+const linters = [];
+
+if (scripts || runAll) {
+  runEslint();
+}
+
+if (styles || runAll) {
+  runStylelint();
+}
+
+if (locales || runAll) {
+  runThemelint();
+}

--- a/packages/slate-tools/cli/index.js
+++ b/packages/slate-tools/cli/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const spawn = require('cross-spawn');
 const analytics = require('@shopify/slate-analytics');
-const { getSlateConfig } = require('@shopify/slate-config');
+const {getSlateConfig} = require('@shopify/slate-config');
 const packageJson = require('../package.json');
 
 const script = process.argv[2];
@@ -22,10 +22,12 @@ async function init() {
     case 'deploy':
     case 'start':
     case 'zip':
+    case 'lint':
+    case 'format':
       result = spawn.sync(
         'node',
         [require.resolve(`./commands/${script}`)].concat(args),
-        { stdio: 'inherit' },
+        {stdio: 'inherit'},
       );
       process.exit(result.status);
       break;

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -21,8 +21,9 @@
     "@shopify/slate-cssvar-loader": "^1.0.0-alpha.24",
     "@shopify/slate-env": "^1.0.0-alpha.24",
     "@shopify/slate-liquid-asset-loader": "^1.0.0-alpha.24",
-    "@shopify/slate-tag-webpack-plugin": "^1.0.0-alpha.24",
     "@shopify/slate-sync": "^1.0.0-alpha.24",
+    "@shopify/slate-tag-webpack-plugin": "^1.0.0-alpha.24",
+    "@shopify/theme-lint": "^2.0.0",
     "@shopify/themekit": "0.6.11",
     "archiver": "^2.1.0",
     "autoprefixer": "6.7.7",
@@ -56,6 +57,7 @@
     "ora": "^1.3.0",
     "postcss-loader": "2.0.5",
     "postcss-reporter": "^5.0.0",
+    "prettier": "^1.10.2",
     "raw-loader": "^0.5.1",
     "react-dev-utils": "0.5.2",
     "sass-loader": "6.0.5",
@@ -69,6 +71,7 @@
     "webpack-hot-middleware": "2.18.0",
     "webpack-merge": "4.1.0",
     "write-file-webpack-plugin": "4.0.2",
-    "yamljs": "0.2.10"
+    "yamljs": "0.2.10",
+    "yargs": "^11.0.0"
   }
 }

--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -174,6 +174,15 @@ module.exports = generate({
           ],
         },
         {
+          id: 'themelint',
+          items: [
+            {
+              id: 'bin',
+              default: path.resolve(__dirname, 'node_modules/.bin/theme-lint'),
+            },
+          ],
+        },
+        {
           id: 'ssl',
           items: [
             {

--- a/packages/slate-tools/tools/eslint/__tests__/index.test.js
+++ b/packages/slate-tools/tools/eslint/__tests__/index.test.js
@@ -1,0 +1,50 @@
+jest.mock('child_process', () => ({execSync: jest.fn()}));
+
+const {execSync} = require.requireMock('child_process');
+
+describe('eslint()', () => {
+  beforeEach(() => {
+    execSync.mockClear();
+  });
+
+  test('executes the ESLint bin found in slate-tools/node_modules', () => {
+    const {eslint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    eslint();
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(config.paths.eslint.bin),
+      expect.anything(),
+    );
+  });
+
+  test('caches test results for quicker repeated executiong', () => {
+    const {eslint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    eslint();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('--cache true --cache-location'),
+      expect.anything(),
+    );
+  });
+
+  test('executes ESLint with no warnings', () => {
+    const {eslint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    eslint();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('--max-warnings 0'),
+      expect.anything(),
+    );
+  });
+
+  test('executes ESLint with the --fix flag', () => {
+    const {eslint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    eslint({fix: true});
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('--fix'),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/slate-tools/tools/eslint/index.js
+++ b/packages/slate-tools/tools/eslint/index.js
@@ -1,0 +1,42 @@
+const execSync = require('child_process').execSync;
+const path = require('path');
+
+const config = require('../../slate-tools.config');
+
+function eslint({fix} = {}) {
+  const executable = config.paths.eslint.bin;
+  const cachePath = path.join(config.paths.cache, 'eslint-scripts');
+  const extensions = ['.js'];
+  const ignorePatterns = ['dist', 'node_modules'].reduce(
+    (buffer, pattern) => `${buffer} --ignore-pattern ${pattern}`,
+    '',
+  );
+  const fixFlag = fix ? '--fix' : '';
+
+  execSync(
+    // prettier-ignore
+    `${JSON.stringify(executable)} . ${extensions} ${ignorePatterns} ` +
+    `${fixFlag} --max-warnings 0 ` +
+    `--cache true --cache-location ${JSON.stringify(`${cachePath}${path.sep}`)}`,
+    {stdio: 'inherit'},
+  );
+}
+
+module.exports.eslint = eslint;
+
+module.exports.runEslint = function runEslint() {
+  console.log('Linting script files...\n');
+  try {
+    eslint();
+  } catch (error) {
+    console.log(`\nESLint errors found.\n`);
+  }
+};
+
+module.exports.runEslintFix = function runEslintFix() {
+  try {
+    eslint({fix: true});
+  } catch (error) {
+    console.log(`\nESLint errors found.\n`);
+  }
+};

--- a/packages/slate-tools/tools/prettier/__tests__/index.test.js
+++ b/packages/slate-tools/tools/prettier/__tests__/index.test.js
@@ -1,0 +1,20 @@
+jest.mock('child_process', () => ({exec: jest.fn()}));
+
+const {exec} = require.requireMock('child_process');
+
+describe('eslint()', () => {
+  beforeEach(() => {
+    exec.mockClear();
+  });
+
+  test('executes the Prettier bin found in slate-tools/node_modules', () => {
+    const {prettier} = require('../index');
+    const config = require('../../../slate-tools.config');
+    prettier();
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith(
+      expect.stringContaining(config.paths.prettier.bin),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/slate-tools/tools/prettier/index.js
+++ b/packages/slate-tools/tools/prettier/index.js
@@ -1,0 +1,33 @@
+const {execSync, exec} = require('child_process');
+const {promisify} = require('util');
+const path = require('path');
+const fs = require('fs');
+
+const config = require('../../slate-tools.config');
+
+async function prettier({scripts, styles, json} = {}) {
+  const executable = config.paths.prettier.bin;
+  const extensions = [
+    ...(scripts ? ['js'] : []),
+    ...(styles ? ['css', 'scss', 'sass'] : []),
+    ...(json ? ['json'] : []),
+  ];
+  const glob =
+    extensions.length > 1
+      ? `./**/*.{${extensions.join(',')}}`
+      : `./**/*.${extensions.join(',')}`;
+
+  try {
+    await promisify(exec)(`${JSON.stringify(executable)} "${glob}" --write`);
+  } catch (error) {
+    if (typeof error.stdout !== 'string') {
+      throw error;
+    }
+  }
+}
+
+module.exports.prettier = prettier;
+
+module.exports.runPrettierJson = async function runPrettierJson() {
+  return await prettier({json: true});
+};

--- a/packages/slate-tools/tools/stylelint/__tests__/index.test.js
+++ b/packages/slate-tools/tools/stylelint/__tests__/index.test.js
@@ -1,0 +1,30 @@
+jest.mock('child_process', () => ({execSync: jest.fn()}));
+
+const {execSync} = require.requireMock('child_process');
+
+describe('stylelint()', () => {
+  beforeEach(() => {
+    execSync.mockClear();
+  });
+
+  test('executes the stylelint bin from slate-tools/node-modules directory', () => {
+    const {stylelint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    stylelint();
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(config.paths.stylelint.bin),
+      expect.anything(),
+    );
+  });
+
+  test('executes ESLint with the --fix flag', () => {
+    const {stylelint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    stylelint({fix: true});
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('--fix'),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/slate-tools/tools/stylelint/index.js
+++ b/packages/slate-tools/tools/stylelint/index.js
@@ -1,0 +1,32 @@
+const execSync = require('child_process').execSync;
+const path = require('path');
+
+const config = require('../../slate-tools.config');
+
+function stylelint({fix} = {}) {
+  const executable = config.paths.stylelint.bin;
+  const fixFlag = fix ? '--fix' : '';
+  const glob = `./**/*.{${['css', 'scss', 'sass'].join(',')}}`;
+  const ignorePatterns = ['dist', 'node_modules'].reduce(
+    (buffer, pattern) => `${buffer} --ignore-pattern ${pattern}`,
+    '',
+  );
+
+  execSync(
+    `${JSON.stringify(executable)} "${glob}" ${ignorePatterns} ${fixFlag}`,
+    {
+      stdio: 'inherit',
+    },
+  );
+}
+
+module.exports.stylelint = stylelint;
+
+module.exports.runStylelint = async function runStylelint() {
+  console.log('Linting style files...\n');
+  stylelint();
+};
+
+module.exports.runStylelintFix = async function runStylelintFix() {
+  stylelint({fix: true});
+};

--- a/packages/slate-tools/tools/theme-lint/__tests__/index.test.js
+++ b/packages/slate-tools/tools/theme-lint/__tests__/index.test.js
@@ -1,0 +1,20 @@
+jest.mock('child_process', () => ({execSync: jest.fn()}));
+
+const {execSync} = require.requireMock('child_process');
+
+describe('themelint()', () => {
+  beforeEach(() => {
+    execSync.mockClear();
+  });
+
+  test('executes the themelint bin from slate-tools/node-modules directory', () => {
+    const {themelint} = require('../index');
+    const config = require('../../../slate-tools.config');
+    themelint();
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(config.paths.themelint.bin),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/slate-tools/tools/theme-lint/index.js
+++ b/packages/slate-tools/tools/theme-lint/index.js
@@ -1,0 +1,20 @@
+const execSync = require('child_process').execSync;
+const path = require('path');
+
+const config = require('../../slate-tools.config');
+
+function themelint() {
+  const executable = config.paths.themelint.bin;
+  const dir = config.paths.src;
+
+  execSync(`${JSON.stringify(executable)} ${dir}`, {
+    stdio: 'inherit',
+  });
+}
+
+module.exports.themelint = themelint;
+
+module.exports.runThemelint = async function runThemelint() {
+  console.log('Linting locales...');
+  return await themelint();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,16 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@shopify/theme-lint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/theme-lint/-/theme-lint-2.0.0.tgz#faf49e09322ea72d8c3615e0e649ecf928f6263b"
+  dependencies:
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    glob "^7.0.6"
+    htmllint "^0.6.0"
+    lodash "^4.15.0"
+
 "@shopify/themekit@0.6.11":
   version "0.6.11"
   resolved "https://registry.yarnpkg.com/@shopify/themekit/-/themekit-0.6.11.tgz#7cd4ca557a04ad1d9b44e09c2043dfc9a6d442ea"
@@ -1506,6 +1516,12 @@ builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
 
+bulk-require@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bulk-require/-/bulk-require-1.0.1.tgz#cb3d039e698139a444fc574b261d6b3b2cf44c89"
+  dependencies:
+    glob "^7.1.1"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -1751,6 +1767,14 @@ cliui@^3.2.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
+cliui@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 clone-deep@^0.2.4:
@@ -4021,7 +4045,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4433,7 +4457,16 @@ html-webpack-plugin@2.28.0:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.9.2:
+htmllint@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/htmllint/-/htmllint-0.6.0.tgz#dbb006676dd66d767cb1b6bb875f08840b91998d"
+  dependencies:
+    bulk-require "^1.0.0"
+    htmlparser2 "^3.7.3"
+    lodash "^4.3.0"
+    promise "^7.1.1"
+
+htmlparser2@^3.7.3, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -7423,7 +7456,7 @@ prettier-stylelint@^0.4.2:
     tempy "^0.2.1"
     update-notifier "^2.2.0"
 
-"prettier@<2.0 >= 1.7.2", prettier@^1.7.0, prettier@^1.7.4:
+"prettier@<2.0 >= 1.7.2", prettier@^1.10.2, prettier@^1.7.0, prettier@^1.7.4:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
@@ -9904,6 +9937,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^6.6.0:
   version "6.6.0"


### PR DESCRIPTION
Adds `lint` and `format` commands to `@shopify/slate-tools`

`lint` command does the following:
- Lints JS files using ESLint and `.eslintrc` 
- Lints CSS, SCSS, and SASS using Stylelint and `.stylelintrc`
- Lints locales using [`@shopify/theme-lint`](https://github.com/Shopify/theme-lint)
- Accepts `--scripts`, `--styles`, and `--locales` flags to selectively lint file types

'format' command does the following:
- Fixes JS files using ESLint `--fix` and `.eslintrc`
- Fixes CSS,SCSS, and SASS using Stylelint `--fix` and `.stylelint.rc`
- Fixes JSON files using Prettier
- Accepts `--scripts`, `--styles`, and `--json` flags to selectively fix file types

Related: https://github.com/Shopify/slate/projects/1#card-6750115, #257 

#### Still Todo
- [x] Add documentation
- [x] Finish tests
- [ ] Error handling

