### PR TITLE
Default to https when cloning new Slate theme

### DIFF
--- a/packages/create-slate-theme/__mocks__/hosted-git-info.js
+++ b/packages/create-slate-theme/__mocks__/hosted-git-info.js
@@ -8,6 +8,9 @@ const TEST_INFO = {
   ssh() {
     return 'git@github.com:shopify/test-repo.git';
   },
+  https() {
+    return 'https://github.com/shopify/test-repo';
+  },
 };
 
 function fromUrl(repo) {

--- a/packages/create-slate-theme/__tests__/create-slate-theme.test.js
+++ b/packages/create-slate-theme/__tests__/create-slate-theme.test.js
@@ -7,13 +7,17 @@ const config = require('../create-slate-theme.config');
 const TEST_PROJECT = 'test-project';
 const TEST_STARTER = 'test-repo';
 const TEST_COMMITTISH = '123456';
-const CLONE_COMMAND = `git clone
+const CLONE_HTTPS_COMMAND = `git clone
+  https://github.com/shopify/${TEST_STARTER}
+  ${path.resolve(TEST_PROJECT)}
+  --single-branch`;
+const CLONE_SSH_COMMAND = `git clone
   git@github.com:shopify/${TEST_STARTER}.git
   ${path.resolve(TEST_PROJECT)}
   --single-branch`;
 const CLONE_BRANCH_COMMAND = `git clone
   -b ${TEST_COMMITTISH}
-  git@github.com:shopify/${TEST_STARTER}.git
+  https://github.com/shopify/${TEST_STARTER}
   ${path.resolve(TEST_PROJECT)}
   --single-branch`;
 
@@ -33,10 +37,19 @@ beforeEach(() => {
   execa().mockClear();
 });
 
-test('can clone a theme from a Github repo', async () => {
-  const [file, ...args] = CLONE_COMMAND.split(/\s+/);
+test('can clone a theme from a Git repo using HTTPS', async () => {
+  const [file, ...args] = CLONE_HTTPS_COMMAND.split(/\s+/);
 
   await createSlateTheme('test-project', 'shopify/test-repo');
+
+  expect(fs.existsSync('test-project/package.json')).toBeTruthy();
+  expect(execa()).toHaveBeenCalledWith(file, args, {stdio: 'pipe'});
+});
+
+test('can clone a theme from a Git repo using SSH', async () => {
+  const [file, ...args] = CLONE_SSH_COMMAND.split(/\s+/);
+
+  await createSlateTheme('test-project', 'shopify/test-repo', {ssh: true});
 
   expect(fs.existsSync('test-project/package.json')).toBeTruthy();
   expect(execa()).toHaveBeenCalledWith(file, args, {stdio: 'pipe'});

--- a/packages/create-slate-theme/__tests__/index.test.js
+++ b/packages/create-slate-theme/__tests__/index.test.js
@@ -47,6 +47,21 @@ test('Calls createSlateTheme with the default repo if process.argv[3] is undefin
   process.argv = args;
 });
 
+test('Registers an --ssh flag and passes it to Create Slate Theme', () => {
+  const config = Object.assign({}, require('../create-slate-theme.config'));
+  const mockArgs = ['node', 'index.js', 'test-project', '--ssh'];
+
+  config.defaultOptions = Object.assign({}, config.defaultOptions, {ssh: true});
+  process.argv = mockArgs;
+
+  require('./../index.js');
+  expect(require('../create-slate-theme')).toHaveBeenCalledWith(
+    mockArgs[2],
+    config.defaultStarter,
+    config.defaultOptions,
+  );
+});
+
 test('Exits if Node version is lower than 8.9.4', () => {
   Object.defineProperty(process.versions, 'node', {
     value: '8.9.3',

--- a/packages/create-slate-theme/create-slate-theme.config.js
+++ b/packages/create-slate-theme/create-slate-theme.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   defaultOptions: {
     skipInstall: false,
+    ssh: false,
   },
   validFiles: [
     '.DS_Store',

--- a/packages/create-slate-theme/index.js
+++ b/packages/create-slate-theme/index.js
@@ -29,6 +29,7 @@ program
   .usage(`${chalk.green('<theme-directory>')} [starter-theme] [options]`)
   .arguments('<name> [repo]')
   .option('--skipInstall', 'skip installing theme dependencies')
+  .option('--ssh', 'uses SSH to clone git repo')
   .option('--verbose', 'print additional logs')
   .action((name, starter = config.defaultStarter) => {
     themeName = name;
@@ -59,6 +60,7 @@ function assignOption(key) {
 
 const options = {
   skipInstall: assignOption('skipInstall'),
+  ssh: assignOption('ssh'),
 };
 
 createSlateTheme(themeName, themeStarter, options);


### PR DESCRIPTION
Fixes https://github.com/Shopify/slate/issues/444

Switch to use `https` url when cloning Git repos. This will allow public repos (https://github.com/Shopify/starter-theme) to be cloned by users who do not have a Github account.

Also added a `--ssh` flag which will continue to allow developers to use SSH, which is more convenient for private repos.

