### PR TITLE
Fix Node version check and error

### DIFF
--- a/packages/create-slate-theme/index.js
+++ b/packages/create-slate-theme/index.js
@@ -1,53 +1,57 @@
 #!/usr/bin/env node
+/* eslint-disable */
 
-const chalk = require('chalk');
-const program = require('commander');
-const semver = require('semver');
-const createSlateTheme = require('./create-slate-theme');
-const packageJson = require('./package.json');
-const config = require('./create-slate-theme.config');
+/* This file must remain compatible for as many legacy versions of Node as possible. Avoid ES6+ language. */
 
-const currentNodeVersion = process.versions.node;
+var chalk = require('chalk');
+var program = require('commander');
+var semver = require('semver');
+var packageJson = require('./package.json');
+var config = require('./create-slate-theme.config');
+
+var currentNodeVersion = process.versions.node;
 
 if (!semver.satisfies(currentNodeVersion, '>=8.9.4')) {
   console.log(
     chalk.red(
-      `You are running Node ${currentNodeVersion}\n\`` +
-        `Create Slate Theme requires Node 8.9.4 or higher. \n` +
-        `Please update your version of Node.`,
-    ),
+      'You are running Node ' +
+        currentNodeVersion +
+        '\n' +
+        'Create Slate Theme requires Node 8.9.4 or higher. \n' +
+        'Please update your version of Node.'
+    )
   );
 
   process.exit(1);
 }
 
-let themeName;
-let themeStarter;
+var themeName;
+var themeStarter;
 
 program
   .version(packageJson.version)
-  .usage(`${chalk.green('<theme-directory>')} [starter-theme] [options]`)
+  .usage(chalk.green('<theme-directory>') + '[starter-theme] [options]')
   .arguments('<name> [repo]')
   .option('--skipInstall', 'skip installing theme dependencies')
   .option('--ssh', 'uses SSH to clone git repo')
   .option('--verbose', 'print additional logs')
-  .action((name, starter = config.defaultStarter) => {
+  .action((name, starter) => {
     themeName = name;
-    themeStarter = starter;
+    themeStarter = starter || config.defaultStarter;
   })
   .parse(process.argv);
 
 if (typeof themeName === 'undefined') {
   console.error('Please specify the theme directory:');
   console.log(
-    `${chalk.cyan(program.name())} ${chalk.green('<theme-directory>')}`,
+    `${chalk.cyan(program.name())} ${chalk.green('<theme-directory>')}`
   );
   console.log();
   console.log('For example:');
-  console.log(`${chalk.cyan(program.name())} ${chalk.green('my-theme')}`);
+  console.log(chalk.cyan(program.name()) + ' ' + chalk.green('my-theme'));
   console.log();
   console.log(
-    `Run${chalk.cyan(`${program.name()} --help`)} to see all options.`,
+    'Run ' + chalk.cyan(program.name() + ' --help') + ' to see all options.'
   );
   process.exit(1);
 }
@@ -58,9 +62,9 @@ function assignOption(key) {
     : program[key];
 }
 
-const options = {
+var options = {
   skipInstall: assignOption('skipInstall'),
   ssh: assignOption('ssh'),
 };
 
-createSlateTheme(themeName, themeStarter, options);
+require('./create-slate-theme')(themeName, themeStarter, options);


### PR DESCRIPTION
Previously, the JS file that checked what version of Node was running was using JS language features available only in Node 6+. This caused a runtime error when the file was run in Node <6.

Switch out Node 6+ features for equivalent legacy alternatives so the Node version warning can be displayed. Disable ESLint so that Prettier does not apply ES6 formatting.
