### PR TITLE
Add google_pay as available payment type

### DIFF
--- a/packages/slate-theme/src/sections/footer.liquid
+++ b/packages/slate-theme/src/sections/footer.liquid
@@ -21,7 +21,7 @@
 
   {% if section.settings.show_payment_icons %}
     {% unless shop.enabled_payment_types == empty %}
-      {%- assign payment_icons_available = 'amazon_payments,american_express,apple_pay,bitcoin,cirrus,dankort,diners_club,discover,dogecoin,dwolla,forbrugsforeningen,interac,jcb,klarna,litecoin,maestro,master,paypal,shopify_pay,visa' | split: ',' -%}
+      {%- assign payment_icons_available = 'amazon_payments,american_express,apple_pay,bitcoin,cirrus,dankort,diners_club,discover,dogecoin,dwolla,forbrugsforeningen,google_pay,interac,jcb,klarna,litecoin,maestro,master,paypal,shopify_pay,visa' | split: ',' -%}
 
       <span class="visually-hidden">{{ 'layout.footer.payment_methods' | t }}</span>
       <ul class="payment-icons">


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Add google_pay as available payment type. This will need to be merged after https://github.com/Shopify/shopify/pull/148070.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

