### PR TITLE
Add --skipPrompts flag

### DIFF
--- a/packages/slate-sync/__tests__/skip-settings-data.test.js
+++ b/packages/slate-sync/__tests__/skip-settings-data.test.js
@@ -27,20 +27,31 @@ describe('promptIfSettingsData()', () => {
   });
 
   test('prompts user if setting_data.json is not ignored in .env file and included in files to be uploaded', () => {
-    const promptIfSettingsData = require('../prompt-skip-settings-data');
+    const promptIfSettingsData = require('../skip-settings-data');
     env.__setIgnoreValue('');
     promptIfSettingsData(FILES);
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not prompt if --skipPrompts flag is used', () => {
+    const promptIfSettingsData = require('../skip-settings-data');
+    process.argv.push('--skipPrompts');
+
+    promptIfSettingsData([]);
+    expect(inquirer.prompt).toHaveBeenCalledTimes(0);
+
+    process.argv.splice(process.argv.indexOf('--skipPrompts'), 1);
   });
 
   test('does not prompt if settings_data.json is not in the file list', () => {
-    const promptIfSettingsData = require('../prompt-skip-settings-data');
+    const promptIfSettingsData = require('../skip-settings-data');
     env.__setIgnoreValue('');
     promptIfSettingsData([]);
     expect(inquirer.prompt).toHaveBeenCalledTimes(0);
   });
 
   test('does not prompt if setting_data.json is ignored in .env file', () => {
-    const promptIfSettingsData = require('../prompt-skip-settings-data');
+    const promptIfSettingsData = require('../skip-settings-data');
     const globs = [
       '/config/settings_data.json',
       'config/settings_data.json',
@@ -61,7 +72,7 @@ describe('promptIfSettingsData()', () => {
     const config = require('../slate-sync.config');
     config.promptSettings = false;
 
-    const promptIfSettingsData = require('../prompt-skip-settings-data');
+    const promptIfSettingsData = require('../skip-settings-data');
     promptIfSettingsData(FILES);
     expect(inquirer.prompt).toHaveBeenCalledTimes(0);
   });

--- a/packages/slate-sync/package.json
+++ b/packages/slate-sync/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@shopify/slate-sync",
   "version": "1.0.0-alpha.24",
-  "description":
-    "Slate's Shopify API client which handles all theme development requests",
+  "description": "Slate's Shopify API client which handles all theme development requests",
   "repository": "https://github.com/Shopify/slate/tree/1.x/packages/slate-sync",
   "license": "MIT",
   "main": "index.js",
@@ -22,6 +21,7 @@
     "inquirer": "^5.0.1",
     "jest": "20.0.3",
     "minimatch": "^3.0.4",
-    "react-dev-utils": "0.5.2"
+    "react-dev-utils": "0.5.2",
+    "yargs": "^11.0.0"
   }
 }

--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -21,7 +21,7 @@ const openBrowser = require('react-dev-utils/openBrowser');
 const clearConsole = require('react-dev-utils/clearConsole');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const {event} = require('@shopify/slate-analytics');
-const {sync, promptIfPublishedTheme} = require('@shopify/slate-sync');
+const {sync} = require('@shopify/slate-sync');
 const slateEnv = require('@shopify/slate-env');
 
 const config = require('../../slate-tools.config');
@@ -204,7 +204,6 @@ compiler.plugin('done', async stats => {
     console.log(chalk.magenta('\nWatching for changes...'));
   } else {
     if (isFirstDeploy) {
-      await promptIfPublishedTheme().catch(() => process.exit(0));
       isFirstDeploy = false;
     }
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/slate/issues/427

Prompts are helpful for real people who need a little help catching a potential mistake, but they're not as helpful for computers. This PR adds a `--skipPrompts` flag which can be added to `slate-tools start` or `slate-tools deploy` to ignore prompts and continue with default behaviour.

Also removes the prompt in `slate-tools deploy` which asks if you're sure you want to deploy, regardless of the configuration. This prompt was overkill and not needed.