### PR TITLE
Add concat-style-loader to handle Liquid Style files

### DIFF
--- a/packages/concat-style-loader/concat.js
+++ b/packages/concat-style-loader/concat.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+
+function concatStyles(content, rootPath) {
+  const assets = parseImports(content, rootPath).reverse();
+
+  assets.forEach((asset) => {
+    asset.content = concatStyles(asset.content, asset.path);
+    content = inlineAsset(content, asset);
+  });
+
+  return content;
+}
+
+function inlineAsset(content, asset) {
+  const startIndex = asset.match.index;
+  const endIndex = startIndex + asset.match[0].length;
+
+  return content.slice(0, startIndex) + asset.content + content.slice(endIndex);
+}
+
+function parseImports(content, rootPath) {
+  const matches = getImportStatements(content);
+  return matches.map((match) => {
+    const url = getImportURL(match[0]);
+    const assetPath = path.resolve(path.dirname(rootPath), url);
+
+    const content = fetchAssetContent(assetPath);
+
+    return {path: assetPath, content, match};
+  });
+}
+
+function fetchAssetContent(assetPath) {
+  if (!fs.existsSync(assetPath)) {
+    throw new Error(
+      `Concat Style Loader Error: Cannot find asset '${assetPath}'`,
+    );
+  }
+
+  return fs.readFileSync(assetPath, 'utf8');
+}
+
+function getImportStatements(content, ignoreComments = true) {
+  const regex = new RegExp(
+    '(?:@import)(?:\\s)(?:url)?(?:(?:(?:\\()(["\'])?(?:[^"\')]+)\\1(?:\\))|(["\'])(?:.+)\\2)(?:[A-Z\\s])*)+(?:;)',
+    'gi',
+  );
+  const matches = [];
+  let match;
+  while ((match = regex.exec(content))) {
+    match.endIndex = match.index + match[1].length;
+
+    if (matchIsInComment(content, match) && ignoreComments) {
+      continue;
+    }
+
+    matches.push(match);
+  }
+  return matches;
+}
+
+function matchIsInComment(content, match) {
+  // Check comment symbols 1.
+  const startBlockComment = content.lastIndexOf('/*', match.index);
+  const endBlockComment = content.lastIndexOf('*/', match.index);
+  const startLineComment = content.lastIndexOf('//', match.index);
+  const endLineComment = content.lastIndexOf('\n', match.index);
+
+  return (
+    // Contained within a block comment
+    (!(endBlockComment > startBlockComment) && startBlockComment !== -1) ||
+    // Contained within a line comment
+    (startLineComment > endLineComment && startLineComment !== -1)
+  );
+}
+
+function getImportURL(statement) {
+  const regex = new RegExp(/@import\s+(?:url\()?(.+(?=['")]))(?:\))?.*/gi);
+  const match = regex.exec(statement);
+  return match[1]
+    .replace(/\'/g, '')
+    .replace(/\"/g, '')
+    .trim();
+}
+
+module.exports = {
+  concatStyles,
+  getImportStatements,
+  matchIsInComment,
+  getImportURL,
+};

--- a/packages/concat-style-loader/index.js
+++ b/packages/concat-style-loader/index.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const {getOptions} = require('loader-utils');
+
+const {concatStyles} = require('./concat');
+
+module.exports = function(content) {
+  const options = getOptions(this);
+  const rootPath = this.resourcePath;
+
+  content = concatStyles(content, rootPath);
+
+  return `module.exports = ${JSON.stringify(content)}`;
+};

--- a/packages/concat-style-loader/package.json
+++ b/packages/concat-style-loader/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "concat-style-loader",
+  "version": "1.0.0-alpha.26",
+  "description": "Finds CSS custom properties (variables) in your stylesheets and replaces them with their corresponding liquid variable",
+  "main": "index.js",
+  "repository": "https://github.com/Shopify/slate/tree/1.x/packages/slate-cssvar-loader",
+  "author": "Shopify Inc.",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Shopify/slate/issues"
+  },
+  "homepage": "https://github.com/Shopify/slate#readme",
+  "devDependencies": {
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
+    "memory-fs": "^0.4.1",
+    "webpack": "^4.4.1"
+  },
+  "dependencies": {
+    "loader-utils": "^1.1.0"
+  }
+}

--- a/packages/concat-style-loader/test/concat.test.js
+++ b/packages/concat-style-loader/test/concat.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+
+jest.dontMock('fs-extra');
+
+describe('concatStyles()', () => {
+  test('inlines stylesheet files into a single string', async () => {
+    const {concatStyles} = require('../concat');
+    const rootPath = path.resolve(__dirname, './fixtures/style.css');
+    const content = fs.readFileSync(rootPath, 'utf8');
+    const concatenated = fs.readFileSync(
+      require.resolve('./fixtures/concatenated.css'),
+      'utf8',
+    );
+
+    const results = await concatStyles(content, rootPath);
+
+    expect(results.replace(/\s/g, '')).toBe(concatenated.replace(/\s/g, ''));
+  });
+});
+
+describe('getImportStatements()', () => {
+  test('returns an array of CSS @import statements found within a string', () => {
+    const {getImportStatements} = require('../concat');
+    const contents = `
+      @import url('./other.css.liquid');
+      @import url('./another.css.liquid');`;
+    const imports = getImportStatements(contents);
+
+    expect(imports.length).toBe(2);
+    expect(imports[0]).toBeInstanceOf(Array);
+    expect(imports[0][0]).toBe("@import url('./other.css.liquid');");
+  });
+
+  test('ignores @import statements inside comments by default', () => {
+    const {getImportStatements} = require('../concat');
+    const contents = `
+      @import url('./other.css.liquid');
+      /* @import url('./another.css.liquid'); */
+      @import url('./another.css.liquid');`;
+    const imports = getImportStatements(contents);
+
+    expect(imports.length).toBe(2);
+  });
+
+  test('can include @import statements inside comments', () => {
+    const {getImportStatements} = require('../concat');
+    const contents = `
+      @import url('./other.css.liquid');
+      /* @import url('./another.css.liquid'); */
+      @import url('./another.css.liquid');`;
+    const imports = getImportStatements(contents, false);
+
+    expect(imports.length).toBe(3);
+  });
+});
+
+describe('getImportURL()', () => {
+  test('returns a valid URL if @import statement uses single quotes', () => {
+    const {getImportURL} = require('../concat');
+    const url = getImportURL("@import url('foo.css');");
+    expect(url).toBe('foo.css');
+  });
+
+  test('returns a valid URL if @import statement uses single quotes', () => {
+    const {getImportURL} = require('../concat');
+    const url = getImportURL('@import url("foo.css");');
+    expect(url).toBe('foo.css');
+  });
+
+  test('returns a valid URL if @import statement has leading or trailing whitespace', () => {
+    const {getImportURL} = require('../concat');
+    const url = getImportURL('@import url(" foo.css ");');
+    expect(url).toBe('foo.css');
+  });
+});

--- a/packages/concat-style-loader/test/fixtures/another.css
+++ b/packages/concat-style-loader/test/fixtures/another.css
@@ -1,0 +1,3 @@
+h2 {
+  color: yellow;
+}

--- a/packages/concat-style-loader/test/fixtures/concatenated.css
+++ b/packages/concat-style-loader/test/fixtures/concatenated.css
@@ -1,0 +1,15 @@
+h3 {
+  color: purple;
+}
+
+h1 {
+  color: red;
+}
+
+h2 {
+  color: yellow;
+}
+
+body {
+  background-color: blue;
+}

--- a/packages/concat-style-loader/test/fixtures/more.css
+++ b/packages/concat-style-loader/test/fixtures/more.css
@@ -1,0 +1,3 @@
+h3 {
+  color: purple;
+}

--- a/packages/concat-style-loader/test/fixtures/other.css
+++ b/packages/concat-style-loader/test/fixtures/other.css
@@ -1,0 +1,5 @@
+@import url('./more.css');
+
+h1 {
+  color: red;
+}

--- a/packages/concat-style-loader/test/fixtures/style.css
+++ b/packages/concat-style-loader/test/fixtures/style.css
@@ -1,0 +1,6 @@
+@import url('./other.css');
+@import url('./another.css');
+
+body {
+  background-color: blue;
+}

--- a/packages/concat-style-loader/test/helpers/app.js
+++ b/packages/concat-style-loader/test/helpers/app.js
@@ -1,0 +1,1 @@
+import '../fixtures/style.css';

--- a/packages/concat-style-loader/test/helpers/compiler.js
+++ b/packages/concat-style-loader/test/helpers/compiler.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const webpack = require('webpack');
+const memoryfs = require('memory-fs');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = (fixture, options = {}) => {
+  const compiler = webpack({
+    context: __dirname,
+    entry: fixture,
+    output: {
+      path: path.resolve(__dirname),
+      filename: 'bundle.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /.*\.(css|scss|sass)$/,
+          use: ExtractTextPlugin.extract({
+            use: {
+              loader: path.resolve(__dirname, '../../index.js'),
+            },
+          }),
+        },
+      ],
+    },
+    plugins: [new ExtractTextPlugin('styles.css')],
+  });
+
+  compiler.outputFileSystem = new memoryfs();
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) reject(err);
+
+      resolve(stats);
+    });
+  });
+};

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -47,7 +47,7 @@
     "file-loader": "1.1.11",
     "fs-extra": "3.0.1",
     "html-loader": "^0.5.5",
-    "html-webpack-include-assets-plugin": "^1.0.2",
+    "html-webpack-include-assets-plugin": "^1.0.4",
     "html-webpack-plugin": "^3.0.6",
     "img-loader": "2.0.1",
     "inquirer": "^5.0.1",

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -9,6 +9,7 @@ const webpackCoreConfig = require('./core');
 const userWebpackConfig = require('../get-user-webpack-config')('dev');
 const config = require('../../../slate-tools.config');
 const {templateFiles, layoutFiles} = require('../entrypoints');
+const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-chunks');
 
 // so that everything is absolute
 webpackCoreConfig.output.publicPath = `${config.domain}:${config.port}/`;
@@ -92,6 +93,8 @@ module.exports = merge(
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
       }),
+
+      new HtmlWebpackIncludeLiquidStylesPlugin(),
     ],
   },
   userWebpackConfig,

--- a/packages/slate-tools/tools/webpack/html-webpack-include-chunks.js
+++ b/packages/slate-tools/tools/webpack/html-webpack-include-chunks.js
@@ -1,0 +1,55 @@
+const minimatch = require('minimatch');
+
+class HtmlWebpackIncludeLiquidStylesPlugin {
+  constructor(options) {
+    this.options = options;
+    this.files = [];
+  }
+
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      'htmlWebpackIncludeChunksPlugin',
+      this.onCompilation.bind(this),
+    );
+  }
+
+  onCompilation(compilation) {
+    this.compilation = compilation;
+
+    compilation.hooks.htmlWebpackPluginAlterChunks.tap(
+      'htmlWebpackIncludeChunksPlugin',
+      this.onAlterChunks.bind(this),
+    );
+
+    compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tap(
+      'htmlWebpackIncludeChunksPlugin',
+      this.onBeforeHtmlGeneration.bind(this),
+    );
+  }
+
+  onAlterChunks(chunks, cb) {
+    this.chunks = chunks;
+  }
+
+  onBeforeHtmlGeneration(htmlPluginData, cb) {
+    const assets = htmlPluginData.assets;
+    const publicPath = assets.publicPath;
+
+    this.chunks.forEach((chunk) => {
+      const name = chunk.names[0];
+      const files = [].concat;
+      const chunkFiles = []
+        .concat(chunk.files)
+        .map((chunkFile) => publicPath + chunkFile);
+
+      const css = chunkFiles
+        .filter((chunkFile) => /.(css|scss)\.liquid($|\?)/.test(chunkFile))
+        .map((chunkFile) => chunkFile.replace(/(\.css)?\.liquid$/, '.css'));
+
+      assets.chunks[name].css = css;
+      assets.css = assets.css.concat(css);
+    });
+  }
+}
+
+module.exports = HtmlWebpackIncludeLiquidStylesPlugin;

--- a/packages/slate-tools/tools/webpack/static-files-glob.js
+++ b/packages/slate-tools/tools/webpack/static-files-glob.js
@@ -24,6 +24,8 @@
 // The context we look for, and replace, is the `__app[src|vendors]__` part.
 //
 var dynamicCtx = 'salut';
-require('__appsrc__/' + dynamicCtx + '.liquid');
-// require('__appsrc__/' + dynamicCtx + '.json');
+require('__appsrc__/layout' + dynamicCtx + '.liquid');
+require('__appsrc__/sections' + dynamicCtx + '.liquid');
+require('__appsrc__/snippets' + dynamicCtx + '.liquid');
+require('__appsrc__/templates' + dynamicCtx + '.liquid');
 require('__appvendors__/' + dynamicCtx);

--- a/packages/slate-tools/tools/webpack/style-tags.html
+++ b/packages/slate-tools/tools/webpack/style-tags.html
@@ -1,7 +1,10 @@
-<% if (!htmlWebpackPlugin.options.isDevServer) { %>
-  <% for (var css in htmlWebpackPlugin.files.css) { %>
-    <% var basename = htmlWebpackPlugin.files.css[css].split('/').reverse()[0]; %>
+
+<% for (var css in htmlWebpackPlugin.files.css) { %>
+  <% var basename = htmlWebpackPlugin.files.css[css].split('/').reverse()[0]; %>
+  <% var isLiquidStyle = /.liquidStyle.css$/.test(basename) %>
+  <% if (!htmlWebpackPlugin.options.isDevServer || isLiquidStyle) { %>
     <% var src = `{{ '${basename}' | asset_url }}` %>
-    <link href="<%= src %>" rel="stylesheet">
+    <link type="text/css" href="<%= src %>" rel="stylesheet">
   <% } %>
 <% } %>
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -5005,7 +5005,7 @@ html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
-html-webpack-include-assets-plugin@^1.0.2:
+html-webpack-include-assets-plugin@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.4.tgz#279cfdf001301f5a945b2525f7f6394d48a3a157"
   dependencies:
@@ -10809,6 +10809,30 @@ webpack@^3.8.1:
 webpack@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.3.0.tgz#0b0c1e211311b3995dd25aed47ab46ea658be070"
+  dependencies:
+    acorn "^5.0.0"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^0.1.1"
+    enhanced-resolve "^4.0.0"
+    eslint-scope "^3.7.1"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.2"
+    tapable "^1.0.0"
+    uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.0.1"
+
+webpack@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.4.1.tgz#b0105789890c28bfce9f392623ef5850254328a4"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^3.0.0"


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #258 

Adds legacy support to `.scss.liquid` and `.css.liquid` files. Replaces any CSS `@import` declarations with the inlined file, similar to [`gulp-cssimport`](https://github.com/unlight/gulp-cssimport) used by Slate v0.

Generates a `theme.scss.liquid` file which will be compiled by Shopify servers.

### TODO

- [x] Test with `slate-tools start`
- [x] Figure out how this plays with locally compiled `.scss`
- [ ] Add documentation
- [x] Clean up `package.json`

