### PR TITLE
Add --replace flag to the deploy command

### DIFF
--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -40,7 +40,7 @@ function _generateIgnoreFlags() {
   const ignoreFiles = slateEnv.getIgnoreFilesValue().split(':');
   const flags = [];
 
-  ignoreFiles.forEach(pattern => {
+  ignoreFiles.forEach((pattern) => {
     flags.push('--ignored-file');
     flags.push(pattern);
   });
@@ -69,7 +69,7 @@ async function deploy(cmd = '', files = []) {
   }
 
   if (await skipSettingData(files)) {
-    files = files.filter(file => !file.endsWith('settings_data.json'));
+    files = files.filter((file) => !file.endsWith('settings_data.json'));
   }
 
   console.log(chalk.magenta(`\n${figures.arrowUp}  Uploading to Shopify...\n`));
@@ -97,7 +97,7 @@ function promiseThemekitConfig() {
         ],
         cwd: config.paths.dist,
       },
-      err => {
+      (err) => {
         if (err) {
           reject(err);
         } else {
@@ -120,7 +120,7 @@ function promiseThemekitDeploy(cmd, files) {
         ],
         cwd: config.paths.dist,
       },
-      err => {
+      (err) => {
         if (err) {
           reject(err);
         } else {
@@ -142,7 +142,11 @@ module.exports = {
     return maybeDeploy();
   },
 
-  async overwrite(env) {
+  async replace() {
     return deploy('replace');
+  },
+
+  async upload() {
+    return deploy('upload');
   },
 };

--- a/packages/slate-tools/README.md
+++ b/packages/slate-tools/README.md
@@ -39,11 +39,12 @@ Here are the available API commands for Slate:
 
 * Builds a production-ready version of the theme and outputs it to the `dist` folder
 
-`deploy [--env=my-custom-env-name] [--skipPrompts]`
+`deploy [--env=my-custom-env-name] [--skipPrompts] [--replace]`
 
 * Push the compiled theme from the `dist` folder to Shopify
 * (Optional) You can pass it an environment as a flag; e.g. `--env=my-custom-env-name` would look for `.env.my-custom-env-name` file
 * (Optional) You can skip all prompts using the `--skipPrompts` flag. This is especially useful when using Slate Tools in CI.
+* (Optional) By default, the deploy command updates any existing files, and adds any new files to your Shopify store's theme. Use this flag to replace all files on your theme with those of your Slate project. This will delete all files from your Shopify theme which are not in your Slate project.
 
 `zip`
 

--- a/packages/slate-tools/cli/commands/deploy.js
+++ b/packages/slate-tools/cli/commands/deploy.js
@@ -1,19 +1,21 @@
 const argv = require('minimist')(process.argv.slice(2));
 const chalk = require('chalk');
 const {event} = require('@shopify/slate-analytics');
-const {overwrite} = require('@shopify/slate-sync');
+const {replace, upload} = require('@shopify/slate-sync');
 const setEnvironment = require('../../tools/webpack/set-slate-env');
 const packageJson = require('../../package.json');
 
 event('slate-tools:deploy:start', {version: packageJson.version});
 setEnvironment(argv.env);
 
-overwrite()
+const deploy = argv.replace ? replace : upload;
+
+deploy()
   .then(() => {
     event('slate-tools:deploy:end', {version: packageJson.version});
     return console.log(chalk.green('\nFiles overwritten successfully!\n'));
   })
-  .catch(error => {
+  .catch((error) => {
     event('slate-tools:deploy:error', {
       version: packageJson.version,
       error,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #463 

Changes the default behaviour of the Slate Tools `deploy` command so that, by default, it only updates and adds new files to a specified theme. This behaviour DOES NOT delete files which are not in your Slate project.

The previous behaviour of deploy, one which replaces all files on your store's theme with that of your Slate project, can be enabled via the `--replace` flag. This behaviour DOES result in the deletion of files which are not in your Slate project.
