### PR TITLE
Add whitespace control for contact template's theme area

### DIFF
--- a/packages/slate-theme/src/templates/page.contact.liquid
+++ b/packages/slate-theme/src/templates/page.contact.liquid
@@ -44,9 +44,9 @@
     name="contact[body]"
     id="ContactFormMessage"
     placeholder="{{ 'contact.form.message' | t }}">
-    {% if form.body %}
-      {{ form.body }}
-    {% endif %}
+    {%- if form.body -%}
+      {{- form.body -}}
+    {%- endif -%}
   </textarea>
 
   <input type="submit" class="btn" value="{{ 'contact.form.send' | t }}">


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
[Fixes issue #343](https://github.com/Shopify/slate/issues/343) - implement whitespace control in textarea's {{form.body}} to prevent empty spaces. This patch will prevent users from entering only white space characters in the specified textarea.




### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

