### PR TITLE
[slate-cssvar-loader] Escape double quotes from liquid variable

### DIFF
--- a/packages/slate-cssvar-loader/__tests__/fixtures/css-variables.liquid
+++ b/packages/slate-cssvar-loader/__tests__/fixtures/css-variables.liquid
@@ -15,5 +15,6 @@
     --color_main_bg: {{ settings.color_main_bg }};
     --header_family: {{ header_family }};
     --letter_spacing: {{ settings.letter_spacing }}px;
+    --font-body-bold-weight: {{ font_body_bold.weight | default: "bold" }};
   }
 </style>

--- a/packages/slate-cssvar-loader/__tests__/fixtures/expected-disabled.js
+++ b/packages/slate-cssvar-loader/__tests__/fixtures/expected-disabled.js
@@ -3,6 +3,6 @@ exports = module.exports = require("../../node_modules/css-loader/lib/css-base.j
 
 
 // module
-exports.push([module.id, ".heading {\n  color: var(--headings_color);\n  background-color: '#FF00FF';\n  letter-spacing: var(--letter_spacing);\n}\n\n.title {\n  color: var(--headings_color);\n}\n\nbody {\n  background-color: var(--body_color);\n}", ""]);
+exports.push([module.id, ".heading {\n  color: var(--headings_color);\n  background-color: '#FF00FF';\n  letter-spacing: var(--letter_spacing);\n}\n\n.title {\n  color: var(--headings_color);\n  font-weight: var(--font-body-bold-weight);\n}\n\nbody {\n  background-color: var(--body_color);\n}", ""]);
 
 // exports

--- a/packages/slate-cssvar-loader/__tests__/fixtures/expected.js
+++ b/packages/slate-cssvar-loader/__tests__/fixtures/expected.js
@@ -3,6 +3,6 @@ exports = module.exports = require("../../node_modules/css-loader/lib/css-base.j
 
 
 // module
-exports.push([module.id, ".heading {\n  color: {{ settings.headings_color }};\n  background-color: '#FF00FF';\n  letter-spacing: {{ settings.letter_spacing }}px;\n}\n\n.title {\n  color: {{ settings.headings_color }};\n}\n\nbody {\n  background-color: {{ settings.body_color }};\n}", ""]);
+exports.push([module.id, ".heading {\n  color: {{ settings.headings_color }};\n  background-color: '#FF00FF';\n  letter-spacing: {{ settings.letter_spacing }}px;\n}\n\n.title {\n  color: {{ settings.headings_color }};\n  font-weight: {{ font_body_bold.weight | default: \"bold\" }};\n}\n\nbody {\n  background-color: {{ settings.body_color }};\n}", ""]);
 
 // exports

--- a/packages/slate-cssvar-loader/__tests__/fixtures/test.css
+++ b/packages/slate-cssvar-loader/__tests__/fixtures/test.css
@@ -6,6 +6,7 @@
 
 .title {
   color: var(--headings_color);
+  font-weight: var(--font-body-bold-weight);
 }
 
 body {

--- a/packages/slate-cssvar-loader/index.js
+++ b/packages/slate-cssvar-loader/index.js
@@ -24,11 +24,15 @@ function parseCSSVariables(cssVariablesPaths) {
       let cssVariableDecl;
       while ((cssVariableDecl = CSS_VAR_DECL_REGEX.exec(styleBlock)) != null) {
         const [, cssVariable, liquidVariable] = cssVariableDecl;
-        variables[cssVariable] = liquidVariable;
+        variables[cssVariable] = escapeLiquidVariable(liquidVariable);
       }
     }
   });
   return variables;
+}
+
+function escapeLiquidVariable(variable) {
+  return variable.replace(/"/g, '\\"');
 }
 
 function SlateCSSLoader(source) {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Escapes double quotes from liquid variables during cssvar replacement.
Fixes #511

### Checklist

For maintainers:
- [x] I have :tophat:'d these changes.

