### PR TITLE
Change the the default CSS var declaration file to theme.liquid

### DIFF
--- a/packages/slate-cssvar-loader/slate-cssvar-loader.config.js
+++ b/packages/slate-cssvar-loader/slate-cssvar-loader.config.js
@@ -11,7 +11,7 @@ module.exports = generate({
     },
     {
       id: 'cssVarLoaderLiquidPath',
-      default: [resolveTheme('src/snippets/css-variables.liquid')],
+      default: [resolveTheme('src/layout/theme.liquid')],
       description:
         'An array of string paths to liquid files that associate css variables to liquid variables',
       type: 'array',


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

We currently require users to create a [`snippets/css-variables.liquid`](https://github.com/Shopify/starter-theme/blob/91a62bad7da4666b561a2e053551e35c36ff7cd6/src/snippets/css-variables.liquid) file in order to use Slate out of the box. This file is used to declare CSS variables which are linked to Liquid variables.

This snippet is completely unnecessary, and the creation of a snippet should be left to the discretion of the theme developer. Let's default to using `layout/theme.liquid` as the file in which we search for CSS variable declarations.

To reverse this behaviour, developers can specify a snippet by declaring the following in their `slate.config.js`:

```
module.exports = {
  slateCssVarLoader: {
    cssVarLoaderLiquidPath: [ __dirname + 'src/snippets/css-variables.liquid'];
  }
};
```
