### PR TITLE
Remove circular reference in Slate Analytics event

### DIFF
--- a/packages/slate-tools/cli/commands/build.js
+++ b/packages/slate-tools/cli/commands/build.js
@@ -9,7 +9,6 @@ const webpackConfig = require('../../tools/webpack/config/prod');
 const packageJson = require('../../package.json');
 
 event('slate-tools:build:start', {
-  webpackConfig,
   version: packageJson.version,
 });
 
@@ -17,7 +16,6 @@ webpack(webpackConfig, (err, stats) => {
   if (err) throw err;
 
   event('slate-tools:build:end', {
-    webpackConfig,
     version: packageJson.version,
   });
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

The webpackConfig object passed to Slate Analytics had a circular reference within in, which does not play well with `JSON.stringify`. We don't really need to be collecting the config for now so I just removed it.
