### PR TITLE
Update the URL for analytics docs

### DIFF
--- a/packages/slate-analytics/prompt.js
+++ b/packages/slate-analytics/prompt.js
@@ -25,7 +25,7 @@ function forNewConsent() {
   );
   console.log(
     chalk.cyan(
-      '\n  https://github.com/Shopify/slate/tree/1.x/packages/slate-analytics',
+      '\n  https://github.com/Shopify/slate/wiki/Slate-Analytics',
     ),
   );
   console.log();


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Now that Slate v1 is in master branch, the URL presented when we ask for consent to collect analytics data is out of date. This updates that URL to reference the docs in the Slate wiki.

