### PR TITLE
Modified slate-cssvar-loader to allow CSS variables without Liquid variables

### DIFF
--- a/packages/slate-cssvar-loader/index.js
+++ b/packages/slate-cssvar-loader/index.js
@@ -7,19 +7,13 @@ const STYLE_BLOCK_REGEX = /(?:<style>|\{% style %\})([\S\s]*?)(?:<\/style>|\{% e
 const CSS_VAR_FUNC_REGEX = /var\(--(.*?)\)/g;
 const CSS_VAR_DECL_REGEX = /--(.*?):\s*(\{\{\s*.*?\s*\}\}.*?);/g;
 
-class SlateException {
-  constructor(message) {
-    this.message = message;
-    this.name = 'SlateException';
-  }
-}
-
 function parseCSSVariables(cssVariablesPaths) {
   const variables = {};
   let styleBlock;
-  cssVariablesPaths.forEach(cssVariablesPath => {
+  cssVariablesPaths.forEach((cssVariablesPath) => {
     const themeFilePath = slateConfig.resolveTheme(cssVariablesPath);
     const content = fs.readFileSync(themeFilePath, 'utf8');
+
     while ((styleBlock = STYLE_BLOCK_REGEX.exec(content)) != null) {
       let cssVariableDecl;
       while ((cssVariableDecl = CSS_VAR_DECL_REGEX.exec(styleBlock)) != null) {
@@ -42,19 +36,20 @@ function SlateCSSLoader(source) {
 
   const cssVariablesPaths = config.cssVarLoaderLiquidPath;
 
-  cssVariablesPaths.forEach(filePath => this.addDependency(filePath));
+  cssVariablesPaths.forEach((filePath) => this.addDependency(filePath));
   const variables = parseCSSVariables(cssVariablesPaths);
 
-  const result = source.replace(CSS_VAR_FUNC_REGEX, (match, cssVariable) => {
+  return source.replace(CSS_VAR_FUNC_REGEX, (match, cssVariable) => {
     if (!variables[cssVariable]) {
-      throw new SlateException(
-        `Liquid variable not found for CSS variable ${cssVariable}`,
+      console.warn(
+        `Liquid variable not found for CSS variable "${cssVariable}"`,
       );
+
+      return match;
     }
+
     return variables[cssVariable];
   });
-
-  return result;
 }
 
 module.exports = SlateCSSLoader;


### PR DESCRIPTION
Modified slate-cssvar-loader not to prevent deploying when no matching liquid variable is found for a CSS variable.

### What are you trying to accomplish with this PR?

I'm attempting to solve the issue I reported that prevents the use of regular CSS variables without corresponding Liquid variables.
https://github.com/Shopify/slate/issues/524

I do not believe any documentation for local SASS compilation needs to be updated to reflect this change. This documentation is the most relevant:
https://github.com/Shopify/slate/wiki/Local-SASS-compilation

### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

