### PR TITLE
Set CSSNano z-index to false in production config

### DIFF
--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -104,7 +104,12 @@ module.exports = merge(
                 options: {
                   ident: 'postcss',
                   sourceMap: true,
-                  plugins: [autoprefixer, cssnano],
+                  plugins: [
+                    autoprefixer,
+                    cssnano({
+                      zindex: false,
+                    }),
+                  ],
                 },
               },
               {loader: 'sass-loader', options: {sourceMap: true}},


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #535.

When running `yarn build` or `yarn deploy`, CSS selectors containing a `z-index` value will be updated to `z-index: 1`. This is due to the CSSNano plugin rebasing these values upon production build.

For more information: http://cssnano.co/optimisations/zindex/

By setting the `zindex` property to `false`, we can omit this change upon build.

### Checklist
For maintainers:
- [x] I have :tophat:'d these changes.