### PR TITLE
Fix the version of slate and slate-tools used by slate-theme

### DIFF
--- a/packages/slate-cli/src/commands/migrate.js
+++ b/packages/slate-cli/src/commands/migrate.js
@@ -16,7 +16,8 @@ export default function(program) {
       const answers = await prompt({
         type: 'confirm',
         name: 'confirmation',
-        message: 'Warning! This will change your theme\'s folder structure. Are you sure you want to proceed?',
+        message:
+          "Warning! This will change your theme's folder structure. Are you sure you want to proceed?",
       });
 
       if (!answers.confirmation) {
@@ -25,7 +26,11 @@ export default function(program) {
 
       if (!utils.isShopifyTheme(workingDirectory)) {
         console.log('');
-        console.error(yellow('  The current directory doesn\'t have /layout/theme.liquid. We have to assume this isn\'t a Shopify theme'));
+        console.error(
+          yellow(
+            "  The current directory doesn't have /layout/theme.liquid. We have to assume this isn't a Shopify theme",
+          ),
+        );
         console.log('');
         console.error(red(`  ${figures.cross} Migration failed`));
         console.log('');
@@ -41,12 +46,20 @@ export default function(program) {
       const scriptsDir = join(srcDir, 'scripts');
 
       console.log('');
-      console.log(`  ${green(figures.tick)} Your theme is a valid Shopify theme`);
+      console.log(
+        `  ${green(figures.tick)} Your theme is a valid Shopify theme`,
+      );
       console.log('');
 
       if (existsSync(srcDir)) {
-        console.error(yellow('  Migrate task could not create a new src directory since your theme already has one'));
-        console.error(yellow('  Please remove or rename your current src directory'));
+        console.error(
+          yellow(
+            '  Migrate task could not create a new src directory since your theme already has one',
+          ),
+        );
+        console.error(
+          yellow('  Please remove or rename your current src directory'),
+        );
         console.log('');
         console.error(red(`  ${figures.cross} Migration failed`));
         console.log('');
@@ -81,8 +94,12 @@ export default function(program) {
       }
 
       const configDirFiles = readdirSync(configDir);
-      const themeSettingsFiles = configDirFiles.filter(utils.isShopifyThemeSettingsFile);
-      const unminifyPromises = themeSettingsFiles.map(unminifyJsonPromiseFactory);
+      const themeSettingsFiles = configDirFiles.filter(
+        utils.isShopifyThemeSettingsFile,
+      );
+      const unminifyPromises = themeSettingsFiles.map(
+        unminifyJsonPromiseFactory,
+      );
 
       try {
         await Promise.all(movePromises);
@@ -97,13 +114,26 @@ export default function(program) {
         console.log('');
 
         if (options.yarn) {
-          await utils.startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
-            cwd: workingDirectory,
-          });
+          await utils.startProcess(
+            'yarn',
+            ['add', '@shopify/slate-tools@slate-v0', '--dev', '--exact'],
+            {
+              cwd: workingDirectory,
+            },
+          );
         } else {
-          await utils.startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
-            cwd: workingDirectory,
-          });
+          await utils.startProcess(
+            'npm',
+            [
+              'install',
+              '@shopify/slate-tools@slate-v0',
+              '--save-dev',
+              '--save-exact',
+            ],
+            {
+              cwd: workingDirectory,
+            },
+          );
         }
 
         console.log('');
@@ -111,12 +141,22 @@ export default function(program) {
         console.log('');
 
         if (!existsSync(configYml)) {
-          const configUrl = 'https://raw.githubusercontent.com/Shopify/slate//master/packages/slate-theme/config-sample.yml';
+          const configUrl =
+            'https://raw.githubusercontent.com/Shopify/slate//master/packages/slate-theme/config-sample.yml';
 
-          await utils.downloadFromUrl(configUrl, join(workingDirectory, 'config.yml'));
+          await utils.downloadFromUrl(
+            configUrl,
+            join(workingDirectory, 'config.yml'),
+          );
 
-          console.error(`  ${green(figures.tick)} Configuration file generated`);
-          console.error(yellow('  Your theme was missing config.yml in the root directory. Please open and edit it before using Slate commands'));
+          console.error(
+            `  ${green(figures.tick)} Configuration file generated`,
+          );
+          console.error(
+            yellow(
+              '  Your theme was missing config.yml in the root directory. Please open and edit it before using Slate commands',
+            ),
+          );
           console.log('');
         }
 
@@ -125,7 +165,11 @@ export default function(program) {
       } catch (err) {
         console.error(red(`  ${err}`));
         console.log('');
-        console.error(red(`  ${figures.cross} Migration failed. Please check src/ directory`));
+        console.error(
+          red(
+            `  ${figures.cross} Migration failed. Please check src/ directory`,
+          ),
+        );
         console.log('');
       }
     });

--- a/packages/slate-cli/src/commands/theme.js
+++ b/packages/slate-cli/src/commands/theme.js
@@ -5,13 +5,21 @@ import {prompt} from 'inquirer';
 import rimraf from 'rimraf';
 import {green, red} from 'chalk';
 import figures from 'figures';
-import {downloadFromUrl, unzip, renameFile, startProcess, writePackageJsonSync} from '../utils';
+import {
+  downloadFromUrl,
+  unzip,
+  renameFile,
+  startProcess,
+  writePackageJsonSync,
+} from '../utils';
 
 export default function(program) {
   program
     .command('theme [name]')
     .alias('t')
-    .description('Generates a new theme directory containing Slate\'s theme boilerplate.')
+    .description(
+      "Generates a new theme directory containing Slate's theme boilerplate.",
+    )
     .option('--yarn', 'installs theme dependencies with yarn instead of npm')
     .action(async (name, options = {}) => {
       let dirName = name;
@@ -20,7 +28,8 @@ export default function(program) {
         const answers = await prompt({
           type: 'input',
           name: 'dirName',
-          message: 'Please enter a directory name for your theme (a new folder will be created):',
+          message:
+            'Please enter a directory name for your theme (a new folder will be created):',
           default: 'theme',
           validate: (value) => {
             const validateName = value.match(/^[\w^'@{}[\],$=!#().%+~\- ]+$/);
@@ -42,7 +51,9 @@ export default function(program) {
 
       if (existsSync(root)) {
         console.log('');
-        console.error(red(`  ${figures.cross} The ${root} directory already exists`));
+        console.error(
+          red(`  ${figures.cross} The ${root} directory already exists`),
+        );
         console.log('');
         return null;
       }
@@ -58,20 +69,35 @@ export default function(program) {
           return unzip(themeZipFile, root);
         })
         .then(() => {
-          console.log(`  ${green(figures.tick)} slate-theme download completed`);
+          console.log(
+            `  ${green(figures.tick)} slate-theme download completed`,
+          );
 
           const pkg = join(root, 'package.json');
 
           writePackageJsonSync(pkg, dirName);
 
           if (options.yarn) {
-            return startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
-              cwd: root,
-            });
+            return startProcess(
+              'yarn',
+              ['add', '@shopify/slate-tools@slate-v0', '--dev', '--exact'],
+              {
+                cwd: root,
+              },
+            );
           } else {
-            return startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
-              cwd: root,
-            });
+            return startProcess(
+              'npm',
+              [
+                'install',
+                '@shopify/slate-tools@slate-v0',
+                '--save-dev',
+                '--save-exact',
+              ],
+              {
+                cwd: root,
+              },
+            );
           }
         })
         .then(() => {
@@ -82,7 +108,6 @@ export default function(program) {
           return null;
         })
         .then(async () => {
-
           const sampleFiles = [
             {oldFile: 'config-sample.yml', newFile: 'config.yml', dir: root},
             {oldFile: '.gitignore-sample', newFile: '.gitignore', dir: root},
@@ -101,7 +126,6 @@ export default function(program) {
           }
 
           return null;
-
         })
         .catch((err) => {
           console.error(red(`  ${err}`));

--- a/packages/slate-theme/package.json
+++ b/packages/slate-theme/package.json
@@ -3,13 +3,9 @@
   "version": "0.13.0",
   "private": true,
   "author": "Shopify Inc.",
-  "description": "A theme scaffold and command line tool for developing Shopify themes.",
-  "keywords": [
-    "slate",
-    "shopify",
-    "theme",
-    "CLI"
-  ],
+  "description":
+    "A theme scaffold and command line tool for developing Shopify themes.",
+  "keywords": ["slate", "shopify", "theme", "CLI"],
   "homepage": "https://shopify.github.io/slate/",
   "bugs": "https://github.com/Shopify/slate/issues",
   "license": "MIT",
@@ -21,8 +17,8 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@shopify/slate": "^0.13.0",
-    "@shopify/slate-tools": "^0.13.0",
+    "@shopify/slate": "0.13.0",
+    "@shopify/slate-tools": "0.13.0",
     "jest": "^20.0.4"
   }
 }


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/544

Makes sure we install `@shopify/slate-tools@slate-v0`, which will always point to the latest `0.x` version of Slate.