### PR TITLE
Fix currency JS formatting names to match Shopify core

### DIFF
--- a/packages/slate-theme/src/scripts/slate/currency.js
+++ b/packages/slate-theme/src/scripts/slate/currency.js
@@ -8,7 +8,7 @@
  *
  */
 
-slate.Currency = (function() {
+slate.Currency = (function () {
   var moneyFormat = '${{amount}}';
 
   /**
@@ -51,14 +51,11 @@ slate.Currency = (function() {
       case 'amount_no_decimals':
         value = formatWithDelimiters(cents, 0);
         break;
-      case 'amount_with_space_separator':
-        value = formatWithDelimiters(cents, 2, ' ', '.');
+      case 'amount_with_comma_separator':
+        value = formatWithDelimiters(cents, 2, '.', ',');
         break;
       case 'amount_no_decimals_with_comma_separator':
-        value = formatWithDelimiters(cents, 0, ',', '.');
-        break;
-      case 'amount_no_decimals_with_space_separator':
-        value = formatWithDelimiters(cents, 0, ' ');
+        value = formatWithDelimiters(cents, 0, '.', ',');
         break;
     }
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/543

