### PR TITLE
Add SLATE_USER_EMAIL env variable for slate-analytics

### DIFF
--- a/packages/slate-analytics/__tests__/index.test.js
+++ b/packages/slate-analytics/__tests__/index.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+
 jest.mock('../prompt');
 jest.mock('axios');
 
@@ -98,6 +100,24 @@ describe('init()', () => {
       expect(config.tracking).toBe(true);
       expect(rc.get().tracking).toBe(true);
       expect(config.trackingVersion).toBe(packageJson.trackingVersion);
+    });
+  });
+
+  describe('skips prompting new user for tracking consent', () => {
+    test('if SLATE_USER_EMAIL environment variable is set to a valid email', async () => {
+      const analytics = require('../index');
+      const prompt = require('../prompt');
+      const mock = require('mock-fs');
+
+      process.env.SLATE_USER_EMAIL = 'test@email.com';
+
+      mock();
+
+      await analytics.init();
+
+      expect(prompt.forNewConsent).not.toHaveBeenCalled();
+
+      delete process.env.SLATE_USER_EMAIL;
     });
   });
 });

--- a/packages/slate-analytics/index.js
+++ b/packages/slate-analytics/index.js
@@ -3,8 +3,10 @@
 const uuidGenerator = require('uuid/v4');
 const clearConsole = require('react-dev-utils/clearConsole');
 const rc = require('@shopify/slate-rc');
+const {getUserEmail} = require('@shopify/slate-env');
 const axios = require('axios');
 const prompt = require('./prompt');
+const {validateEmail} = require('./utils');
 const packageJson = require('./package.json');
 
 async function init() {
@@ -21,8 +23,15 @@ async function init() {
   ) {
     if (typeof config.tracking === 'undefined') {
       // If new user
-      const answers = await prompt.forNewConsent();
-      config = Object.assign({}, config, answers, {
+      let email = getUserEmail();
+
+      if (!validateEmail(email)) {
+        const answer = await prompt.forNewConsent();
+        email = answer.email;
+      }
+
+      config = Object.assign({}, config, {
+        email,
         tracking: true,
         trackingVersion: packageJson.trackingVersion,
       });

--- a/packages/slate-analytics/package.json
+++ b/packages/slate-analytics/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/shopify/slate#readme",
   "dependencies": {
+    "@shopify/slate-env": "^1.0.0-beta.1",
     "@shopify/slate-error": "^1.0.0-beta.1",
     "@shopify/slate-rc": "^1.0.0-beta.1",
     "axios": "^0.18.0",

--- a/packages/slate-analytics/prompt.js
+++ b/packages/slate-analytics/prompt.js
@@ -2,16 +2,14 @@ const inquirer = require('inquirer');
 const clearConsole = require('react-dev-utils/clearConsole');
 const wrap = require('word-wrap');
 const chalk = require('chalk');
+const {validateEmail} = require('./utils');
 
 const question = {
   type: 'input',
   name: 'email',
   message: 'To continue, please enter your email address:',
   validate: (input) => {
-    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(String(input).toLowerCase())
-      ? true
-      : 'Email not valid. Please try again.';
+    return validateEmail(input) || 'Email not valid. Please try again.';
   },
 };
 

--- a/packages/slate-analytics/utils.js
+++ b/packages/slate-analytics/utils.js
@@ -1,0 +1,6 @@
+module.exports = {
+  validateEmail(input) {
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(input).toLowerCase());
+  },
+};

--- a/packages/slate-env/__tests__/index.test.js
+++ b/packages/slate-env/__tests__/index.test.js
@@ -14,6 +14,7 @@ const TEST_ENV = {
   [config.envPasswordVar]: '123456789',
   [config.envThemeIdVar]: '987654321',
   [config.envIgnoreFilesVar]: 'config/settings_data.json',
+  [config.envUserEmail]: 'test@email.com',
 };
 
 function setVars(vars) {
@@ -61,6 +62,19 @@ describe('Slate Env', () => {
 
     test('returns object containing all env variables without current values', () => {
       expect(slateEnv.getSlateEnv()).toEqual(TEST_ENV);
+    });
+  });
+
+  describe('getDefaultSlateEnv', () => {
+    test('returns an object which contains the default variables and values of an env file', () => {
+      const emptyTestVars = {
+        [config.envStoreVar]: '',
+        [config.envPasswordVar]: '',
+        [config.envThemeIdVar]: '',
+        [config.envIgnoreFilesVar]: '',
+      };
+
+      expect(slateEnv.getDefaultSlateEnv()).toEqual(emptyTestVars);
     });
   });
 

--- a/packages/slate-env/index.js
+++ b/packages/slate-env/index.js
@@ -11,6 +11,14 @@ const SLATE_ENV_VARS = [
   config.envPasswordVar,
   config.envThemeIdVar,
   config.envIgnoreFilesVar,
+  config.envUserEmail,
+];
+
+const DEFAULT_ENV_VARS = [
+  config.envStoreVar,
+  config.envPasswordVar,
+  config.envThemeIdVar,
+  config.envIgnoreFilesVar,
 ];
 
 // Creates a new env file with optional name and values
@@ -33,9 +41,7 @@ function _getFileName(name) {
 
 // Return default list of env variables with their assigned value, if any.
 function _getFileContents(values) {
-  const env = getEmptySlateEnv();
-
-  delete env[config.envNameVar];
+  const env = getDefaultSlateEnv();
 
   for (const key in values) {
     if (values.hasOwnProperty(key) && env.hasOwnProperty(key)) {
@@ -190,6 +196,16 @@ function getEmptySlateEnv() {
   return env;
 }
 
+function getDefaultSlateEnv() {
+  const env = {};
+
+  DEFAULT_ENV_VARS.forEach((key) => {
+    env[key] = '';
+  });
+
+  return env;
+}
+
 function getEnvNameValue() {
   return process.env[config.envNameVar];
 }
@@ -215,16 +231,23 @@ function getIgnoreFilesValue() {
   return typeof value === 'undefined' ? '' : value;
 }
 
+function getUserEmail() {
+  const value = process.env[config.envUserEmail];
+  return typeof value === 'undefined' ? '' : value;
+}
+
 module.exports = {
   create,
   assign,
   validate,
   clear,
   getSlateEnv,
+  getDefaultSlateEnv,
   getEmptySlateEnv,
   getEnvNameValue,
   getStoreValue,
   getPasswordValue,
   getThemeIdValue,
   getIgnoreFilesValue,
+  getUserEmail,
 };

--- a/packages/slate-env/slate-env.config.js
+++ b/packages/slate-env/slate-env.config.js
@@ -59,5 +59,11 @@ module.exports = slateConfig.generate({
         "A list of file patterns to ignore, with each list item separated by ':'",
       type: 'string',
     },
+    {
+      id: 'envUserEmail',
+      default: 'SLATE_USER_EMAIL',
+      description: 'The email of the user to register for Slate analytics',
+      type: 'string',
+    },
   ],
 });


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/585
Related https://github.com/Shopify/slate/issues/552

Adds a new environment variable `SLATE_USER_EMAIL` to `@shopify/slate-env`. When setting this value to a valid email, `@shopify/slate-analytics` will use it to consent to data collection instead of prompting the user.

cc @markdavies