### PR TITLE
Add webpack.ProvidePlugin config object

### DIFF
--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -36,6 +36,13 @@ module.exports = generate({
       default: true,
     },
     {
+      id: 'providerPlugin',
+      default: {},
+      description:
+        'Automatically load modules instead of having to import or require them everywhere',
+      type: 'object',
+    },
+    {
       id: 'extends',
       items: [
         {

--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -36,7 +36,7 @@ module.exports = generate({
       default: true,
     },
     {
-      id: 'providerPlugin',
+      id: 'providePlugin',
       default: {},
       description:
         'Automatically load modules instead of having to import or require them everywhere',

--- a/packages/slate-tools/tools/webpack/config/core.js
+++ b/packages/slate-tools/tools/webpack/config/core.js
@@ -133,7 +133,7 @@ module.exports = {
   plugins: [
     ...contextReplacementPlugins(),
 
-    new webpack.ProvidePlugin(config.providerPlugin),
+    new webpack.ProvidePlugin(config.providePlugin),
 
     extractLiquidStyles,
 

--- a/packages/slate-tools/tools/webpack/config/core.js
+++ b/packages/slate-tools/tools/webpack/config/core.js
@@ -133,6 +133,8 @@ module.exports = {
   plugins: [
     ...contextReplacementPlugins(),
 
+    new webpack.ProvidePlugin(config.providerPlugin),
+
     extractLiquidStyles,
 
     new CopyWebpackPlugin([


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Add a way to pass through a [webpack.ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/) object from the `slate.config.js` file to the `core.js` configuration.  Originally, I had attempted to add the webpack.ProvidePlugin plugin to the dev/prod extends in `slate.config.js`, however I'm fairly certain that it was not working because it was loaded prior to the HotModuleReplacementPlugin.

- Issue: Loading Webpack Plugins to expose jQuery to 3rd party modules #575

Below is an example `slate.config.js` file that automatically loads $ and jQuery modules, which solves issues with including most jQuery plugins where jQuery would not be defined.  Additionally, there is another example where Lodash Map is added as a provide plugin.

```js
/* eslint-disable no-undef */

const path = require('path');

const alias = {
  jquery: path.resolve('./node_modules/jquery'),
  'lodash-es': path.resolve('./node_modules/lodash-es'),
};

module.exports = {
  slateCssVarLoader: {
    cssVarLoaderLiquidPath: ['src/snippets/css-variables.liquid'],
  },
  slateTools: {
    providePlugin: {
      $: 'jquery',
      jQuery: 'jquery',
      _map: ['lodash-es', 'map'],
    },
    extends: {
      dev: {resolve: {alias}},
      prod: {resolve: {alias}},
    },
  },
};
```

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

As an alternate approach, it might make sense to add a way to extend core for plugins or loaders that need to be covered across dev/prod or need to be added prior to dev/prod.