### PR TITLE
Add static folder to list of ignore patterns

### DIFF
--- a/packages/slate-tools/tools/eslint/index.js
+++ b/packages/slate-tools/tools/eslint/index.js
@@ -7,7 +7,7 @@ function eslint({fix} = {}) {
   const executable = config.paths.eslint.bin;
   const cachePath = path.join(config.paths.cache, 'eslint-scripts');
   const extensions = ['.js'];
-  const ignorePatterns = ['dist', 'node_modules'].reduce(
+  const ignorePatterns = ['dist', 'node_modules', 'src/assets/static'].reduce(
     (buffer, pattern) => `${buffer} --ignore-pattern ${pattern}`,
     '',
   );


### PR DESCRIPTION
Fixes https://github.com/Shopify/slate/issues/596.  Adds the `src/assets/static` folder to the list of ignore patterns as part of Slate Tools.

There is currently another PR that does the same thing on the theme level: https://github.com/Shopify/starter-theme/pull/83.