### PR TITLE
BREAKING: Add load logic and preload future styles and scripts

### DIFF
--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -102,6 +102,8 @@ module.exports = merge(
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
+        liquidTemplates: templateFiles(),
+        liquidLayouts: layoutFiles(),
       }),
 
       new HtmlWebpackIncludeLiquidStylesPlugin(),

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -116,6 +116,8 @@ module.exports = merge(
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
+        liquidTemplates: templateFiles(),
+        liquidLayouts: layoutFiles(),
       }),
 
       new HtmlWebpackIncludeLiquidStylesPlugin(),

--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -8,13 +8,15 @@
 
   <% if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
     {%- if template.name == '<%= chunk.split('.')[1] %>' -%}
-      <!--[if (gt IE 9)|!(IE)]><!--><script type="text/javascript" src="<%= src %>" defer></script><!--<![endif]-->
-      <!--[if lte IE 9]><script type="text/javascript" src="<%= src %>"></script><![endif]-->
+      <script type="text/javascript" src="<%= src %>" defer></script>
+    {%- else -%}
+      <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
   <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[chunk] !== 'undefined') { %>
     {%- if layout == '<%= chunk.split('.')[1] %>' -%}
-      <!--[if (gt IE 9)|!(IE)]><!--><script type="text/javascript" src="<%= src %>" defer></script><!--<![endif]-->
-      <!--[if lte IE 9]><script type="text/javascript" src="<%= src %>"></script><![endif]-->
+      <script type="text/javascript" src="<%= src %>" defer></script>
+    {%- else -%}
+      <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
   <% } else if (chunk.split('@').length > 1) { %>
     <% var pages = chunk.split('@').slice(1) %>
@@ -29,11 +31,11 @@
     <% }); %>
 
     {%- if <%= conditions.join(' or ') %> -%}
-      <!--[if (gt IE 9)|!(IE)]><!--><script type="text/javascript" src="<%= src %>" defer></script><!--<![endif]-->
-      <!--[if lte IE 9]><script type="text/javascript" src="<%= src %>"></script><![endif]-->
+      <script type="text/javascript" src="<%= src %>" defer></script>
+    {%- else -%}
+      <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
   <% } else { %>
-    <!--[if (gt IE 9)|!(IE)]><!--><script type="text/javascript" src="<%= src %>" defer></script><!--<![endif]-->
-    <!--[if lte IE 9]><script type="text/javascript" src="<%= src %>"></script><![endif]-->
+    <script type="text/javascript" src="<%= src %>" defer></script>
   <% } %>
 <% } %>

--- a/packages/slate-tools/tools/webpack/style-tags.html
+++ b/packages/slate-tools/tools/webpack/style-tags.html
@@ -1,10 +1,43 @@
 
 <% for (var css in htmlWebpackPlugin.files.css) { %>
   <% var basename = htmlWebpackPlugin.files.css[css].split('/').reverse()[0]; %>
+  <% var chunkName = basename.replace('.scss', '').replace('.css', '').replace('.styleLiquid', ''); %>
   <% var isLiquidStyle = /.liquidStyle.css$/.test(basename) %>
+
   <% if (!htmlWebpackPlugin.options.isDevServer || isLiquidStyle) { %>
     <% var src = `{{ '${basename}' | asset_url }}` %>
-    <link type="text/css" href="<%= src %>" rel="stylesheet">
+
+    <% if (typeof htmlWebpackPlugin.options.liquidTemplates[chunkName] !== 'undefined') { %>
+      {%- if template.name == '<%= chunkName.split('.')[1] %>' -%}
+        <link type="text/css" href="<%= src %>" rel="stylesheet">
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="style">
+      {%- endif -%}
+    <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[chunkName] !== 'undefined') { %>
+      {%- if layout == '<%= chunkName.split('.')[1] %>' -%}
+        <link type="text/css" href="<%= src %>" rel="stylesheet">
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="style">
+      {%- endif -%}
+    <% } else if (chunkName.split('@').length > 1) { %>
+      <% var pages = chunkName.split('@').slice(1) %>
+      <% var conditions = [] %>
+
+      <% pages.forEach(function(page){ %>
+        <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
+          <% conditions.push("template.name == '" + page.split('.')[1] + "'") %>
+        <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[page] !== 'undefined') { %>
+          <% conditions.push("layout == '" + page.split('.')[1] + "'") %>
+        <% } %>
+      <% }); %>
+
+      {%- if <%= conditions.join(' or ') %> -%}
+        <link type="text/css" href="<%= src %>" rel="stylesheet">
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="style">
+      {%- endif -%}
+    <% } else { %>
+      <link type="text/css" href="<%= src %>" rel="stylesheet">
+    <% } %>
   <% } %>
 <% } %>
-


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/587

Adds similar logic used in `script-tags.liquid` to intelligently load stylesheets according to the current layout and template.

Users will now need to specify the layout name when including the `style-tags.liquid` snippet, similar to the `script-tags.liquid` snippet.

Also adds `prefetch` logic to all scripts and styles that are not needed for the current page. This will improve page load performance of future navigated pages! Woohoo!

cc @et1421

