### PR TITLE
Fix build break when missing fonts directory

### DIFF
--- a/packages/slate-tools/tools/webpack/config/core.js
+++ b/packages/slate-tools/tools/webpack/config/core.js
@@ -133,32 +133,34 @@ module.exports = {
 
     extractLiquidStyles,
 
-    new CopyWebpackPlugin([
-      {
-        from: paths.svgs,
-        to: `${paths.snippets.dist}/[name].liquid`,
-      },
-      {
-        from: paths.static.src,
-        to: paths.static.dist,
-      },
-      {
-        from: paths.images.src,
-        to: paths.images.dist,
-      },
-      {
-        from: paths.fonts.src,
-        to: paths.fonts.dist,
-      },
-      {
-        from: paths.locales.src,
-        to: paths.locales.dist,
-      },
-      {
-        from: paths.settings.src,
-        to: paths.settings.dist,
-      },
-    ]),
+    new CopyWebpackPlugin(
+      [
+        {
+          from: paths.svgs,
+          to: `${paths.snippets.dist}/[name].liquid`,
+        },
+        {
+          from: paths.static.src,
+          to: paths.static.dist,
+        },
+        {
+          from: paths.images.src,
+          to: paths.images.dist,
+        },
+        {
+          from: paths.fonts.src,
+          to: paths.fonts.dist,
+        },
+        {
+          from: paths.locales.src,
+          to: paths.locales.dist,
+        },
+        {
+          from: paths.settings.src,
+          to: paths.settings.dist,
+        },
+      ].filter((directory) => fs.existsSync(directory.from)),
+    ),
 
     new WriteFileWebpackPlugin({
       test: /^(?:(?!hot-update.json$).)*\.(liquid|json)$/,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Last released introduced a bug which would cause your build to fail if your project didn't have a folder that has its contents copied to dist, e.g if you were missing the `src/assets/fonts` directory. This removes the requirement to have these folders.

