### PR TITLE
Fix middleware module overwriting compiler watchOptions

### DIFF
--- a/packages/slate-tools/tools/dev-server/app.js
+++ b/packages/slate-tools/tools/dev-server/app.js
@@ -10,7 +10,7 @@ module.exports = class App {
     app.webpackDevMiddleware = webpackDevMiddleware(compiler, {
       quiet: true,
       reload: true,
-      watchOptions: compiler.options.watchOptions || {}
+      watchOptions: compiler.options.watchOptions || {},
     });
     app.webpackHotMiddleware = webpackHotMiddleware(compiler, {
       log: false,

--- a/packages/slate-tools/tools/dev-server/app.js
+++ b/packages/slate-tools/tools/dev-server/app.js
@@ -10,6 +10,7 @@ module.exports = class App {
     app.webpackDevMiddleware = webpackDevMiddleware(compiler, {
       quiet: true,
       reload: true,
+      watchOptions: compiler.options.watchOptions || {}
     });
     app.webpackHotMiddleware = webpackHotMiddleware(compiler, {
       log: false,


### PR DESCRIPTION
The `webpack-dev-middleware` module sets the compiler's `watchOptions` object even if the middleware module's object is empty and the compiler's is not. This means any changes made to the compiler config `watchOptions` object are overwritten and not used.

Fixed by passing in the compiler's `watchOptions` object if it is set.

I can't submit a PR to fix the issue in the `webpack-dev-middleware` module because slate-tools requires v1.10.2 which is two major versions behind.

### What are you trying to accomplish with this PR?

Fixes #672


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

