### PR TITLE
Add an option to disable SSL.

### DIFF
--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -49,6 +49,10 @@ module.exports = generate({
       ],
     },
     {
+      id: 'ssl',
+      default: true,
+    },
+    {
       id: 'domain',
       default: 'https://localhost',
     },

--- a/packages/slate-tools/tools/dev-server/index.js
+++ b/packages/slate-tools/tools/dev-server/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const webpack = require('webpack');
-const {createServer} = require('https');
+const {createServer: createHttpServer} = require('http');
+const {createServer: createHttpsServer} = require('https');
 const createHash = require('crypto').createHash;
 
 const App = require('./app');
@@ -28,7 +29,11 @@ module.exports = class DevServer {
       'DevServer',
       this._onCompileDone.bind(this),
     );
-    this.server = createServer(ssl(config), this.app);
+    if (config.ssl) {
+      this.server = createHttpsServer(ssl(config), this.app);
+    } else {
+      this.server = createHttpServer(this.app);
+    }
     this.server.listen(config.port);
   }
 


### PR DESCRIPTION
At the moment, I can't seem to get Slate's local Express server to work with AWS Cloud9. This is a small, quick and dirty PR that fixes this. 

C9 only connects to local apps via HTTP (as documented here: https://docs.aws.amazon.com/cloud9/latest/user-guide/app-preview.html#app-preview-run-app). However, it will serve these apps to remote browsers over HTTPS. So simply disabling SSL allows Slate to be used from a Cloud9 instance.

I don't code much in JS and I'm not familiar with all the JS dev tools so please forgive the lack of tests and any other sins. I've tested it with my C9 instance and a fresh Shopify store and it works like a charm. Is this something the Slate team is willing to officially support?