### PR TITLE
Add the ability to parse .css imports

### DIFF
--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -42,10 +42,7 @@ module.exports = merge(
         },
         {
           test: /\.css$/,
-          use: [
-            {loader: 'style-loader'},
-            {loader: 'css-loader'}
-          ]
+          use: [{loader: 'style-loader'}, {loader: 'css-loader'}],
         },
         {
           test: /\.s[ac]ss$/,

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -41,6 +41,13 @@ module.exports = merge(
           ],
         },
         {
+          test: /\.css$/,
+          use: [
+            {loader: 'style-loader'},
+            {loader: 'css-loader'}
+          ]
+        },
+        {
           test: /\.s[ac]ss$/,
           exclude: commonExcludes(),
           use: [

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -46,7 +46,7 @@ module.exports = merge(
           test: /\.css$/,
           exclude: commonExcludes(),
           use: extractStyles.extract({
-            fallbacl: 'style-loader',
+            fallback: 'style-loader',
             use: [{loader: 'css-loader'}],
           }),
         },

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -43,6 +43,16 @@ module.exports = merge(
           ],
         },
         {
+          test: /\.css$/,
+          exclude: commonExcludes(),
+          use: extractStyles.extract({
+            fallbacl: 'style-loader',
+            use: [
+              {loader: 'css-loader'}
+            ]
+          })
+        },
+        {
           test: /\.s[ac]ss$/,
           exclude: commonExcludes(),
           use: extractStyles.extract({

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -47,10 +47,8 @@ module.exports = merge(
           exclude: commonExcludes(),
           use: extractStyles.extract({
             fallbacl: 'style-loader',
-            use: [
-              {loader: 'css-loader'}
-            ]
-          })
+            use: [{loader: 'css-loader'}],
+          }),
         },
         {
           test: /\.s[ac]ss$/,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

From https://github.com/Shopify/slate/issues/677

Currently slate will fail when trying to import a `.css` file. This is especially useful when wanting to import a packages css files.


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

