### PR TITLE
Add the ability to pass your own PostCSS plugins

### DIFF
--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -28,13 +28,13 @@ module.exports = generate({
       items: [
         {
           id: 'dev',
-          default: []
+          default: [],
         },
         {
           id: 'prod',
-          default: []
-        }
-      ]
+          default: [],
+        },
+      ],
     },
     {
       id: 'cssnanoSettings',

--- a/packages/slate-tools/slate-tools.config.js
+++ b/packages/slate-tools/slate-tools.config.js
@@ -24,6 +24,19 @@ module.exports = generate({
       type: 'path',
     },
     {
+      id: 'postcssPlugins',
+      items: [
+        {
+          id: 'dev',
+          default: []
+        },
+        {
+          id: 'prod',
+          default: []
+        }
+      ]
+    },
+    {
       id: 'cssnanoSettings',
       default: {zindex: false},
       description: 'Optimization settings for the cssnano plugin',

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -63,7 +63,7 @@ module.exports = merge(
               options: {
                 ident: 'postcss',
                 sourceMap: false,
-                plugins: () => [autoprefixer],
+                plugins: () => [...config.postcssPlugins.dev, autoprefixer],
               },
             },
             {loader: 'sass-loader', options: {sourceMap: false}},

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -58,7 +58,7 @@ module.exports = merge(
                 options: {
                   ident: 'postcss',
                   sourceMap: true,
-                  plugins: [autoprefixer, cssnano(config.cssnanoSettings)],
+                  plugins: [...config.postcssPlugins.prod, autoprefixer, cssnano(config.cssnanoSettings)],
                 },
               },
               {loader: 'sass-loader', options: {sourceMap: true}},

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -58,7 +58,11 @@ module.exports = merge(
                 options: {
                   ident: 'postcss',
                   sourceMap: true,
-                  plugins: [...config.postcssPlugins.prod, autoprefixer, cssnano(config.cssnanoSettings)],
+                  plugins: [
+                    ...config.postcssPlugins.prod,
+                    autoprefixer,
+                    cssnano(config.cssnanoSettings),
+                  ],
                 },
               },
               {loader: 'sass-loader', options: {sourceMap: true}},


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

https://github.com/Shopify/slate/issues/540

This will allow the ability to pass Postcss plugins to the postcss-loader in the Webpack config.

This is a very simple version to start with, it could be improved by moving the Autoprefixer & CSSNano parts in to the `slate.config.js` so the user can control the order of them.

I opted to put the custom plugins before the Autoprefixer and CSSNano plugins as i think 99.2% of use cases will want their plugins before any of these so for the initial version it would make sense.

Happy to be pointed towards a relevant place to detail this change somewhere for people.


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

