### PR TITLE
Add .otf font support in webpack config

### DIFF
--- a/packages/slate-tools/tools/webpack/config/core.js
+++ b/packages/slate-tools/tools/webpack/config/core.js
@@ -92,7 +92,7 @@ module.exports = {
         loader: 'hmr-alamo-loader',
       },
       {
-        test: /fonts\/.*\.(eot|svg|ttf|woff|woff2)$/,
+        test: /fonts\/.*\.(eot|svg|ttf|woff|woff2|otf)$/,
         exclude: /node_modules/,
         loader: 'file-loader',
       },


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

This PR extends webpack configuration to support .otf fonts.

I need that for my project but also mentioned here: https://github.com/Shopify/slate/issues/418#issuecomment-392568520


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

