### PR TITLE
Fix conditions for generating script tags

### DIFF
--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -6,20 +6,14 @@
     <% var src = `{{ '${basename}' | asset_url }}` %>
   <% } %>
 
-  <% if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
-    {%- if template.name == '<%= chunk.split('.')[1] %>' -%}
-      <script type="text/javascript" src="<%= src %>" defer></script>
-    {%- else -%}
-      <link rel="prefetch" href="<%= src %>" as="script">
-    {%- endif -%}
-  <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[chunk] !== 'undefined') { %>
+  <% if (typeof htmlWebpackPlugin.options.liquidLayouts[chunk] !== 'undefined') { %>
     {%- if layout == '<%= chunk.split('.')[1] %>' -%}
       <script type="text/javascript" src="<%= src %>" defer></script>
     {%- else -%}
       <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
   <% } else if (chunk.split('@').length > 1) { %>
-    <% var pages = chunk.split('@').slice(1) %>
+    <% var pages = chunk.split('@') %>
     <% var conditions = [] %>
 
     <% pages.forEach(function(page){ %>
@@ -31,6 +25,12 @@
     <% }); %>
 
     {%- if <%= conditions.join(' or ') %> -%}
+      <script type="text/javascript" src="<%= src %>" defer></script>
+    {%- else -%}
+      <link rel="prefetch" href="<%= src %>" as="script">
+    {%- endif -%}
+  <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
+    {%- if template.name == '<%= chunk.split('.')[1] %>' -%}
       <script type="text/javascript" src="<%= src %>" defer></script>
     {%- else -%}
       <link rel="prefetch" href="<%= src %>" as="script">


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/715

Shared bundles (e.g. a bundle named template.index@template.product.js) were not having all pages added to the liquid condition that decided whether the page should be rendered with a `<script>` or `<link>` tag. Instead of generating:
```
{%- if template.name == 'index' or template.name == 'product' -%}
```
it would only generate
```
{%- if template.name == 'product' -%}
```

