### PR TITLE
Stop clearing console when testing

### DIFF
--- a/packages/slate-analytics/index.js
+++ b/packages/slate-analytics/index.js
@@ -49,7 +49,12 @@ async function init() {
       event('slate-analytics:renew-consent-true', config);
     }
 
-    clearConsole();
+    if (
+      process.env.NODE_ENV !== 'test' && // eslint-disable-line no-process-env
+      process.env.NODE_ENV !== 'test-slate-analytics' // eslint-disable-line no-process-env
+    ) {
+      clearConsole();
+    }
     console.log(`Thanks for helping improve the Slate development experience!`);
   }
 

--- a/packages/slate-analytics/prompt.js
+++ b/packages/slate-analytics/prompt.js
@@ -14,7 +14,11 @@ const question = {
 };
 
 function forNewConsent() {
-  clearConsole();
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'test') {
+    clearConsole();
+  }
+
   console.log(
     wrap(
       '👋  Welcome to Slate! During the alpha, we would like to gather usage analytics, such as interactions with Slate commands, performance reports, and error occurances. The data does not include any sensitive information. The detailed list of data we gather can be found at:',

--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -66,7 +66,10 @@ Promise.all([
   });
 
 function onCompilerCompile() {
-  clearConsole();
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'test') {
+    clearConsole();
+  }
   spinner.start();
 }
 
@@ -74,7 +77,11 @@ function onCompilerDone(stats) {
   const statsJson = stats.toJson({}, true);
 
   spinner.stop();
-  clearConsole();
+
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'test') {
+    clearConsole();
+  }
 
   if (statsJson.errors.length) {
     event('slate-tools:start:compile-errors', {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Checks if `process.env.NODE_ENV === 'test'` before clearing the console. It's annoying to see half your test results disappear as you test!