### PR TITLE
Add tests for cssnano config item

### DIFF
--- a/packages/slate-tools/tools/webpack/config/parts/__tests__/sass.prod.test.js
+++ b/packages/slate-tools/tools/webpack/config/parts/__tests__/sass.prod.test.js
@@ -1,0 +1,15 @@
+test(`passes 'webpack.cssnano.settings' config to cssnano`, () => {
+  global.slateUserConfig = {
+    'webpack.cssnano.settings': {some: 'value'},
+  };
+
+  jest.mock('cssnano');
+
+  const cssnano = require('cssnano');
+
+  require('../sass.prod');
+
+  expect(cssnano).toBeCalledWith(
+    global.slateUserConfig['webpack.cssnano.settings'],
+  );
+});

--- a/packages/slate-tools/tools/webpack/config/parts/sass.prod.js
+++ b/packages/slate-tools/tools/webpack/config/parts/sass.prod.js
@@ -1,0 +1,47 @@
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const autoprefixer = require('autoprefixer');
+const cssnano = require('cssnano');
+const SlateConfig = require('@shopify/slate-config');
+
+const commonExcludes = require('../../common-excludes');
+const config = new SlateConfig(require('../../../../slate-tools.schema'));
+
+const extractStyles = new ExtractTextPlugin({
+  filename: '[name].css.liquid',
+  allChunks: true,
+});
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.s[ac]ss$/,
+        exclude: commonExcludes(),
+        use: extractStyles.extract({
+          fallback: 'style-loader',
+          use: [
+            {loader: '@shopify/slate-cssvar-loader'},
+            {
+              loader: 'css-loader',
+              options: {importLoaders: 2, sourceMap: true},
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                ident: 'postcss',
+                sourceMap: true,
+                plugins: [
+                  autoprefixer,
+                  cssnano(config.get('webpack.cssnano.settings')),
+                ],
+              },
+            },
+            {loader: 'sass-loader', options: {sourceMap: true}},
+          ],
+        }),
+      },
+    ],
+  },
+
+  plugins: [extractStyles],
+};


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Followup to https://github.com/Shopify/slate/pull/737

- Adds test for 'webpack.cssnano.settings' which makes sure the config is passed to cssnano
- Isolates the sass rule for webpack in its own file to make it easier to test

