### PR TITLE
Add tests for 'webpack.config.extend.prod' and 'webpack.config.extend.dev'

### DIFF
--- a/packages/slate-tools/tools/webpack/config/__tests__/dev.test.js
+++ b/packages/slate-tools/tools/webpack/config/__tests__/dev.test.js
@@ -1,0 +1,25 @@
+test(`merges contents of 'webpack.config.extend.dev' into webpack config`, () => {
+  global.slateUserConfig = {
+    'webpack.config.extend.dev': {some: 'value'},
+  };
+
+  jest.mock('../core', () => {
+    return {entry: {}};
+  });
+  jest.mock('webpack-merge');
+  jest.mock('../../entrypoints', () => {
+    return {
+      templateFiles: jest.fn(),
+      layoutFiles: jest.fn(),
+    };
+  });
+
+  const merge = require('webpack-merge');
+  require('../dev');
+
+  expect(merge).toBeCalledWith(
+    expect.arrayContaining([
+      global.slateUserConfig['webpack.config.extend.dev'],
+    ]),
+  );
+});

--- a/packages/slate-tools/tools/webpack/config/__tests__/prod.test.js
+++ b/packages/slate-tools/tools/webpack/config/__tests__/prod.test.js
@@ -1,0 +1,26 @@
+test(`merges contents of 'webpack.config.extend.prod' into webpack config`, () => {
+  global.slateUserConfig = {
+    'webpack.config.extend.prod': {some: 'value'},
+  };
+
+  jest.mock('../core', () => {
+    return {entry: {}};
+  });
+  jest.mock('webpack-merge');
+  jest.mock('../../entrypoints', () => {
+    return {
+      templateFiles: jest.fn(),
+      layoutFiles: jest.fn(),
+    };
+  });
+
+  const merge = require('webpack-merge');
+
+  require('../prod');
+
+  expect(merge).toBeCalledWith(
+    expect.arrayContaining([
+      global.slateUserConfig['webpack.config.extend.prod'],
+    ]),
+  );
+});

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -19,7 +19,7 @@ Object.keys(webpackCoreConfig.entry).forEach((name) => {
   ].concat(webpackCoreConfig.entry[name]);
 });
 
-module.exports = merge(
+module.exports = merge([
   webpackCoreConfig,
   babel,
   {
@@ -110,4 +110,4 @@ module.exports = merge(
     ],
   },
   config.get('webpack.config.extend.dev'),
-);
+]);

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -19,7 +19,7 @@ const {templateFiles, layoutFiles} = require('../entrypoints');
 const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-chunks');
 const config = new SlateConfig(require('../../../slate-tools.schema'));
 
-module.exports = merge(
+module.exports = merge([
   webpackCoreConfig,
   babel,
   sass,
@@ -110,4 +110,4 @@ module.exports = merge(
     },
   },
   config.get('webpack.config.extend.prod'),
-);
+]);


### PR DESCRIPTION
Follow-up to #739 

Adds tests that make sure 'webpack.config.extend.prod' and 'webpack.config.extend.dev' are passed to webpack-merge.
