### PR TITLE
Add test for 'webpack.entrypoints' config

### DIFF
--- a/packages/slate-tools/tools/webpack/config/__tests__/dev.test.js
+++ b/packages/slate-tools/tools/webpack/config/__tests__/dev.test.js
@@ -3,18 +3,18 @@ test(`merges contents of 'webpack.config.extend.dev' into webpack config`, () =>
     'webpack.config.extend.dev': {some: 'value'},
   };
 
-  jest.mock('../core', () => {
+  jest.mock('../parts/core', () => {
     return {entry: {}};
   });
-  jest.mock('webpack-merge');
-  jest.mock('../../entrypoints', () => {
-    return {
-      templateFiles: jest.fn(),
-      layoutFiles: jest.fn(),
-    };
+  jest.mock('../parts/entry', () => {
+    return {entry: {}};
   });
+  jest.mock('../utilities/get-layout-entrypoints');
+  jest.mock('../utilities/get-template-entrypoints');
+  jest.mock('webpack-merge');
 
   const merge = require('webpack-merge');
+
   require('../dev');
 
   expect(merge).toBeCalledWith(

--- a/packages/slate-tools/tools/webpack/config/__tests__/prod.test.js
+++ b/packages/slate-tools/tools/webpack/config/__tests__/prod.test.js
@@ -3,16 +3,13 @@ test(`merges contents of 'webpack.config.extend.prod' into webpack config`, () =
     'webpack.config.extend.prod': {some: 'value'},
   };
 
-  jest.mock('../core', () => {
-    return {entry: {}};
+  jest.mock('../parts/core');
+  jest.mock('../parts/entry', () => {
+    return {};
   });
+  jest.mock('../utilities/get-layout-entrypoints');
+  jest.mock('../utilities/get-template-entrypoints');
   jest.mock('webpack-merge');
-  jest.mock('../../entrypoints', () => {
-    return {
-      templateFiles: jest.fn(),
-      layoutFiles: jest.fn(),
-    };
-  });
 
   const merge = require('webpack-merge');
 

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -5,22 +5,26 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const SlateConfig = require('@shopify/slate-config');
 
-const webpackCoreConfig = require('./core');
+const core = require('./parts/core');
 const babel = require('./parts/babel');
+const entry = require('./parts/entry');
+
 const commonExcludes = require('./utilities/common-excludes');
-const {templateFiles, layoutFiles} = require('../entrypoints');
+const getLayoutEntrypoints = require('./utilities/get-layout-entrypoints');
+const getTemplateEntrypoints = require('./utilities/get-template-entrypoints');
 const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-chunks');
 const config = new SlateConfig(require('../../../slate-tools.schema'));
 
 // add hot-reload related code to entry chunks
-Object.keys(webpackCoreConfig.entry).forEach((name) => {
-  webpackCoreConfig.entry[name] = [
-    path.join(__dirname, '../hot-client.js'),
-  ].concat(webpackCoreConfig.entry[name]);
+Object.keys(entry.entry).forEach((name) => {
+  entry.entry[name] = [path.join(__dirname, '../hot-client.js')].concat(
+    entry.entry[name],
+  );
 });
 
 module.exports = merge([
-  webpackCoreConfig,
+  core,
+  entry,
   babel,
   {
     mode: 'development',
@@ -85,8 +89,8 @@ module.exports = merge([
           removeAttributeQuotes: false,
         },
         isDevServer: true,
-        liquidTemplates: templateFiles(),
-        liquidLayouts: layoutFiles(),
+        liquidTemplates: getTemplateEntrypoints(),
+        liquidLayouts: getLayoutEntrypoints(),
       }),
 
       new HtmlWebpackPlugin({
@@ -102,8 +106,8 @@ module.exports = merge([
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
-        liquidTemplates: templateFiles(),
-        liquidLayouts: layoutFiles(),
+        liquidTemplates: getTemplateEntrypoints(),
+        liquidLayouts: getLayoutEntrypoints(),
       }),
 
       new HtmlWebpackIncludeLiquidStylesPlugin(),

--- a/packages/slate-tools/tools/webpack/config/parts/__tests__/entry.test.js
+++ b/packages/slate-tools/tools/webpack/config/parts/__tests__/entry.test.js
@@ -1,0 +1,21 @@
+jest.mock('../../utilities/get-layout-entrypoints', () => {
+  return jest.fn(() => {
+    return {
+      someEntryPoint: 'somePath',
+    };
+  });
+});
+
+jest.mock('../../utilities/get-template-entrypoints', () => {
+  return jest.fn();
+});
+
+test(`copys and overrides values in webpacks entry config with 'webpack.entrypoints' config`, () => {
+  global.slateUserConfig = {
+    'webpack.entrypoints': {someEntryPoint: 'someNewPath'},
+  };
+
+  const {entry} = require('../entry');
+
+  expect(entry).toMatchObject(global.slateUserConfig['webpack.entrypoints']);
+});

--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -6,9 +6,8 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const SlateConfig = require('@shopify/slate-config');
 
-const commonExcludes = require('./utilities/common-excludes');
-const {entrypointFiles} = require('../entrypoints');
-const config = new SlateConfig(require('../../../slate-tools.schema'));
+const commonExcludes = require('../utilities/common-excludes');
+const config = new SlateConfig(require('../../../../slate-tools.schema'));
 
 const extractLiquidStyles = new ExtractTextPlugin(
   '[name].styleLiquid.scss.liquid',
@@ -67,8 +66,6 @@ function contextReplacementPlugins() {
 
 module.exports = {
   context: config.get('paths.theme.src'),
-
-  entry: Object.assign(entrypointFiles(), config.get('webpack.entrypoints')),
 
   output: {
     filename: '[name].js',

--- a/packages/slate-tools/tools/webpack/config/parts/entry.js
+++ b/packages/slate-tools/tools/webpack/config/parts/entry.js
@@ -1,0 +1,13 @@
+const SlateConfig = require('@shopify/slate-config');
+const getLayoutEntrypoints = require('../utilities/get-layout-entrypoints');
+const getTemplateEntrypoints = require('../utilities/get-template-entrypoints');
+const config = new SlateConfig(require('../../../../slate-tools.schema'));
+
+module.exports = {
+  entry: Object.assign(
+    {},
+    getLayoutEntrypoints(),
+    getTemplateEntrypoints(),
+    config.get('webpack.entrypoints'),
+  ),
+};

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -11,16 +11,20 @@ const SlateTagPlugin = require('@shopify/slate-tag-webpack-plugin');
 
 const babel = require('./parts/babel');
 const sass = require('./parts/sass.prod');
+const entry = require('./parts/entry');
+const core = require('./parts/core');
+
 const commonExcludes = require('./utilities/common-excludes');
-const webpackCoreConfig = require('./core');
 const packageJson = require('../../../package.json');
 const getChunkName = require('../get-chunk-name');
-const {templateFiles, layoutFiles} = require('../entrypoints');
+const getLayoutEntrypoints = require('./utilities/get-layout-entrypoints');
+const getTemplateEntrypoints = require('./utilities/get-template-entrypoints');
 const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-chunks');
 const config = new SlateConfig(require('../../../slate-tools.schema'));
 
 module.exports = merge([
-  webpackCoreConfig,
+  core,
+  entry,
   babel,
   sass,
   {
@@ -73,8 +77,8 @@ module.exports = merge([
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
-        liquidTemplates: templateFiles(),
-        liquidLayouts: layoutFiles(),
+        liquidTemplates: getTemplateEntrypoints(),
+        liquidLayouts: getLayoutEntrypoints(),
       }),
 
       new HtmlWebpackPlugin({
@@ -91,8 +95,8 @@ module.exports = merge([
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
-        liquidTemplates: templateFiles(),
-        liquidLayouts: layoutFiles(),
+        liquidTemplates: getTemplateEntrypoints(),
+        liquidLayouts: getLayoutEntrypoints(),
       }),
 
       new HtmlWebpackIncludeLiquidStylesPlugin(),

--- a/packages/slate-tools/tools/webpack/config/utilities/get-layout-entrypoints.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/get-layout-entrypoints.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const SlateConfig = require('@shopify/slate-config');
+const config = new SlateConfig(require('../../../../slate-tools.schema'));
+
+module.exports = function() {
+  const entrypoints = {};
+
+  fs.readdirSync(config.get('paths.theme.src.layouts')).forEach((file) => {
+    const name = path.parse(file).name;
+    const jsFile = path.join(
+      config.get('paths.theme.src.scripts'),
+      'layout',
+      `${name}.js`,
+    );
+    if (fs.existsSync(jsFile)) {
+      entrypoints[`layout.${name}`] = jsFile;
+    }
+  });
+  return entrypoints;
+};

--- a/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
@@ -1,8 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const SlateConfig = require('@shopify/slate-config');
-
-const config = new SlateConfig(require('../../slate-tools.schema'));
+const config = new SlateConfig(require('../../../../slate-tools.schema'));
 
 const VALID_LIQUID_TEMPLATES = [
   '404',
@@ -26,7 +25,7 @@ const VALID_LIQUID_TEMPLATES = [
   'search',
 ];
 
-function templateFiles() {
+module.exports = function() {
   const entrypoints = {};
 
   fs.readdirSync(config.get('paths.theme.src.templates')).forEach((file) => {
@@ -57,30 +56,4 @@ function templateFiles() {
     });
 
   return entrypoints;
-}
-
-function layoutFiles() {
-  const entrypoints = {};
-  fs.readdirSync(config.get('paths.theme.src.layouts')).forEach((file) => {
-    const name = path.parse(file).name;
-    const jsFile = path.join(
-      config.get('paths.theme.src.scripts'),
-      'layout',
-      `${name}.js`,
-    );
-    if (fs.existsSync(jsFile)) {
-      entrypoints[`layout.${name}`] = jsFile;
-    }
-  });
-  return entrypoints;
-}
-
-function entrypointFiles() {
-  return Object.assign({}, layoutFiles(), templateFiles());
-}
-
-module.exports = {
-  templateFiles,
-  layoutFiles,
-  entrypointFiles,
 };


### PR DESCRIPTION
Follow-up to #740 

- Moves `webpack/config/core.js` to `webpack/config/parts/core.js`
- Creates a new `parts/entry.js`
- Isolates logic for determining Template and Layout entrypoints into their own files, get-template-entrypoints.js and get-layout-entrypoints.js
- Adds test which checks if 'webpack.entrypoints' object is merged into the output of `parts/entry.js`
