### PR TITLE
Add config tests for stylelint

### DIFF
--- a/packages/slate-tools/slate-tools.schema.js
+++ b/packages/slate-tools/slate-tools.schema.js
@@ -47,11 +47,11 @@ module.exports = {
   'stylelint.bin': path.resolve(__dirname, 'node_modules/.bin/stylelint'),
 
   // Path to .stylelintrc file
-  'stylelint.rc': (config) =>
+  'stylelint.config': (config) =>
     path.resolve(config.get('paths.theme'), '.stylelintrc'),
 
   // Path to .stylelintignore file
-  'stylelint.ignore': (config) =>
+  'stylelint.ignorePath': (config) =>
     path.resolve(config.get('paths.theme'), '.stylelintignore'),
 
   // Path to Themelint bin executable

--- a/packages/slate-tools/tools/stylelint/__tests__/index.test.js
+++ b/packages/slate-tools/tools/stylelint/__tests__/index.test.js
@@ -7,7 +7,7 @@ describe('stylelint()', () => {
     execSync.mockClear();
   });
 
-  test('executes the stylelint bin from slate-tools/node-modules directory', () => {
+  test(`executes the stylelint bin from the path specified in the 'stylelint.bin' config`, () => {
     const {stylelint} = require('../index');
     const SlateConfig = require('@shopify/slate-config');
     const config = new SlateConfig(require('../../../slate-tools.schema'));
@@ -19,7 +19,31 @@ describe('stylelint()', () => {
     );
   });
 
-  test('executes ESLint with the --fix flag', () => {
+  test(`executes stylelint with the --config flag set to 'stylelint.config' config`, () => {
+    const {stylelint} = require('../index');
+    const SlateConfig = require('@shopify/slate-config');
+    const config = new SlateConfig(require('../../../slate-tools.schema'));
+    stylelint();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(`--config ${config.get('stylelint.config')}`),
+      expect.anything(),
+    );
+  });
+
+  test(`executes stylelint with the --ignore-path flag set to 'stylelint.ignorePath' config`, () => {
+    const {stylelint} = require('../index');
+    const SlateConfig = require('@shopify/slate-config');
+    const config = new SlateConfig(require('../../../slate-tools.schema'));
+    stylelint();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `--ignore-path ${config.get('stylelint.ignorePath')}`,
+      ),
+      expect.anything(),
+    );
+  });
+
+  test('executes stylelint with the --fix flag', () => {
     const {stylelint} = require('../index');
     stylelint({fix: true});
     expect(execSync).toHaveBeenCalledWith(

--- a/packages/slate-tools/tools/stylelint/index.js
+++ b/packages/slate-tools/tools/stylelint/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const execSync = require('child_process').execSync;
 const SlateConfig = require('@shopify/slate-config');
 
@@ -7,13 +8,15 @@ function stylelint({fix} = {}) {
   const executable = config.get('stylelint.bin');
   const fixFlag = fix ? '--fix' : '';
   const glob = `./**/*.{${['css', 'scss', 'sass'].join(',')}}`;
-  const ignorePatterns = ['dist', 'node_modules'].reduce(
-    (buffer, pattern) => `${buffer} --ignore-pattern ${pattern}`,
-    '',
-  );
+  const stylelintConfig = `--config ${config.get('stylelint.config')}`;
+  const ignorePath = fs.existsSync(config.get('stylelint.ignorePath'))
+    ? `--ignore-path ${config.get('stylelint.ignorePath')}`
+    : '';
 
   execSync(
-    `${JSON.stringify(executable)} "${glob}" ${ignorePatterns} ${fixFlag}`,
+    `${JSON.stringify(
+      executable,
+    )} "${glob}" ${stylelintConfig} ${fixFlag} ${ignorePath}`,
     {
       stdio: 'inherit',
     },


### PR DESCRIPTION
Follow-up to #743 

BREAKING: Your project will now require a .stylelintignore file to ignore linting dist/ and node_modules/ directories

- Pass 'stylelint.config' to --config flag
- Pass 'stylelint.ignorePath' to --ignore-path
- Add tests for all config items

