### PR TITLE
Add tests to Eslint config items

### DIFF
--- a/packages/slate-tools/slate-tools.schema.js
+++ b/packages/slate-tools/slate-tools.schema.js
@@ -12,11 +12,12 @@ module.exports = {
   'eslint.bin': path.resolve(__dirname, 'node_modules/.bin/eslint'),
 
   // Path to .eslintignore file
-  'eslint.ignore': (config) =>
+  'eslint.ignorePath': (config) =>
     path.resolve(config.get('paths.theme'), '.eslintignore'),
 
   // Path to .eslintrc file
-  'eslint.rc': (config) => path.resolve(config.get('paths.theme'), '.eslintrc'),
+  'eslint.config': (config) =>
+    path.resolve(config.get('paths.theme'), '.eslintrc'),
 
   // Default port used for asset server. If it is not available, the next port
   // that is available is used.

--- a/packages/slate-tools/tools/eslint/__tests__/index.test.js
+++ b/packages/slate-tools/tools/eslint/__tests__/index.test.js
@@ -7,14 +7,44 @@ describe('eslint()', () => {
     execSync.mockClear();
   });
 
-  test('executes the ESLint bin found in slate-tools/node_modules', () => {
+  test(`executes the Eslint bin from the path specified in the 'eslint.bin' config`, () => {
     const {eslint} = require('../index');
     const SlateConfig = require('@shopify/slate-config');
     const config = new SlateConfig(require('../../../slate-tools.schema'));
+
     eslint();
+
     expect(execSync).toHaveBeenCalledTimes(1);
     expect(execSync).toHaveBeenCalledWith(
       expect.stringContaining(config.get('eslint.bin')),
+      expect.anything(),
+    );
+  });
+
+  test(`executes Prettier with the --config flag set to 'eslint.config' config`, () => {
+    const {eslint} = require('../index');
+    const SlateConfig = require('@shopify/slate-config');
+    const config = new SlateConfig(require('../../../slate-tools.schema'));
+
+    eslint();
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(`--config ${config.get('eslint.config')}`),
+      expect.anything(),
+    );
+  });
+
+  test(`executes Prettier with the --ignore-path flag set to 'eslint.ignorePath' config`, () => {
+    const {eslint} = require('../index');
+    const SlateConfig = require('@shopify/slate-config');
+    const config = new SlateConfig(require('../../../slate-tools.schema'));
+
+    eslint();
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `--ignore-path ${config.get('eslint.ignorePath')}`,
+      ),
       expect.anything(),
     );
   });

--- a/packages/slate-tools/tools/eslint/index.js
+++ b/packages/slate-tools/tools/eslint/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const execSync = require('child_process').execSync;
 const path = require('path');
 const SlateConfig = require('@shopify/slate-config');
@@ -11,15 +12,15 @@ function eslint({fix} = {}) {
     'eslint-scripts',
   );
   const extensions = ['.js'];
-  const ignorePatterns = ['dist', 'node_modules', 'src/assets/static'].reduce(
-    (buffer, pattern) => `${buffer} --ignore-pattern ${pattern}`,
-    '',
-  );
   const fixFlag = fix ? '--fix' : '';
+  const eslintConfig = `--config ${config.get('eslint.config')}`;
+  const ignorePath = fs.existsSync(config.get('eslint.ignorePath'))
+    ? `--ignore-path ${config.get('eslint.ignorePath')}`
+    : '';
 
   execSync(
     // prettier-ignore
-    `${JSON.stringify(executable)} . ${extensions} ${ignorePatterns} ` +
+    `${JSON.stringify(executable)} . ${extensions} ${ignorePath} ${eslintConfig}` +
     `${fixFlag} --max-warnings 0 ` +
     `--cache true --cache-location ${JSON.stringify(`${cachePath}${path.sep}`)}`,
     {stdio: 'inherit'},


### PR DESCRIPTION
BREAKING: Themes will need a .eslintignore file to ignore 'dist', 'node_modules', 'src/assets/static' files

- Pass 'eslint.config' to the --config flag
- Pass 'eslint.ignorePath' to --ignore-path
- Add tests for all config items
