### PR TITLE
Pass computed default value to slate.config.js functions

### DIFF
--- a/packages/slate-config/__tests__/index.test.js
+++ b/packages/slate-config/__tests__/index.test.js
@@ -95,13 +95,34 @@ describe('SlateConfig.get()', () => {
     expect(config.get('some.other.key')).toBe(schema['some.other.key']);
   });
 
-  test('if the value is a function, the function is executed with the config instance as the only argument', () => {
+  test('if the value is a function and not specified in this.userConfig, the function is executed with the config instance as the only argument', () => {
     const SlateConfig = require('../index');
     const config = new SlateConfig(schema);
     const value = config.get('some.function');
 
     expect(schema['some.function']).toBeCalledWith(config);
     expect(value).toBe(schema['some.other.key']);
+  });
+
+  test('if the value is specified in this.userConfig and is a function, it is executed with the config instance and the computed default value as arguments', () => {
+    const userConfigValue = 'someNewValue';
+    const userConfigFunction = jest.fn(() => userConfigValue);
+
+    const SlateConfig = require('../index');
+    const config = new SlateConfig(schema);
+    const defaultValue = config.get('some.function');
+
+    global.slateUserConfig = {
+      'some.function': userConfigFunction,
+    };
+
+    const value = config.get('some.function');
+
+    expect(global.slateUserConfig['some.function']).toBeCalledWith(
+      config,
+      defaultValue,
+    );
+    expect(value).toBe(userConfigValue);
   });
 });
 

--- a/packages/slate-config/index.js
+++ b/packages/slate-config/index.js
@@ -31,20 +31,31 @@ module.exports = class SlateConfig {
   }
 
   get(key) {
-    const userConfig = this.userConfig;
-    const value =
-      typeof userConfig[key] === 'undefined'
-        ? this.schema[key]
-        : userConfig[key];
+    const defaultValue = this.schema[key];
+    const userConfigValue = this.userConfig[key];
+    let computedDefaultValue;
 
-    if (typeof value === 'function') {
-      return value(this);
-    } else if (typeof value === 'undefined') {
+    if (
+      typeof defaultValue === 'undefined' &&
+      typeof userConfigValue === 'undefined'
+    ) {
       throw new Error(
         `[slate-config]: A value has not been defined for the key '${key}'`,
       );
+    }
+
+    if (typeof defaultValue === 'function') {
+      computedDefaultValue = defaultValue(this);
     } else {
-      return value;
+      computedDefaultValue = defaultValue;
+    }
+
+    if (typeof userConfigValue === 'undefined') {
+      return computedDefaultValue;
+    } else if (typeof userConfigValue === 'function') {
+      return userConfigValue(this, computedDefaultValue);
+    } else {
+      return userConfigValue;
     }
   }
 };


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

With the config updates it is possible to set a config value as a function. This function had access to the SlateConfig instance, allowing you to fetch other config values:
```js
// slate-tools.schema.js
module.exports = {
  'webpack.postcss.plugins': (config) => [
    autoprefixer,

    ...(process.env.NODE_ENV === 'production'
      ? [cssnano(config.get('webpack.cssnano.settings'))]
      : []),
  ]
};
```
However, one thing that was not possible to do was extend the default value of a config item. If the above config was the default value declared, and you wanted to add another PostCSS plugin while keeping the defaults, you would need to redeclare the default values plus add your own:

```js
// slate.config.js
const autoprefixer = require('autoprefixer');
const cssnano = require('cssnano');
const newPostCSSPlugin = require('newPostCSSPlugin');

module.exports = {
  'webpack.postcss.plugins': (config) => [
    newPostCSSPlugin,

    autoprefixer,

    ...(process.env.NODE_ENV === 'production'
      ? [cssnano(config.get('webpack.cssnano.settings'))]
      : []),
  ]
};
```
This approach requires you to add these libraries as new dependencies in your theme -- not cool. 

Now, functions in your `slate.config.js` file have direct access to the default value, allowing you to extend it without needing to rewrite it:

```js
// slate.config.js
const newPostCSSPlugin = require('newPostCSSPlugin');

module.exports = {
  'webpack.postcss.plugins': (config, defaultValue) => [
    newPostCSSPlugin,
    ..defaultvalue
  ]
};
```

