### PR TITLE
Fix alternative template bundles

### DIFF
--- a/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
@@ -25,6 +25,13 @@ const VALID_LIQUID_TEMPLATES = [
   'search',
 ];
 
+function isValidTemplate(filename) {
+  const name = VALID_LIQUID_TEMPLATES.filter((template) =>
+    filename.startsWith(`${template}.`),
+  );
+  return Boolean(name);
+}
+
 module.exports = function() {
   const entrypoints = {};
 
@@ -35,7 +42,8 @@ module.exports = function() {
       'templates',
       `${name}.js`,
     );
-    if (VALID_LIQUID_TEMPLATES.includes(name) && fs.existsSync(jsFile)) {
+
+    if (isValidTemplate(name) && fs.existsSync(jsFile)) {
       entrypoints[`template.${name}`] = jsFile;
     }
   });

--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -18,7 +18,7 @@
 
     <% pages.forEach(function(page){ %>
       <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
-        <% conditions.push("template.name == '" + page.split('.')[1] + "'") %>
+        <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
       <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[page] !== 'undefined') { %>
         <% conditions.push("layout == '" + page.split('.')[1] + "'") %>
       <% } %>
@@ -30,7 +30,7 @@
       <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
   <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
-    {%- if template.name == '<%= chunk.split('.')[1] %>' -%}
+    {%- if template == '<%= chunk.split('.').slice(1).join('.') %>' -%}
       <script type="text/javascript" src="<%= src %>" defer></script>
     {%- else -%}
       <link rel="prefetch" href="<%= src %>" as="script">

--- a/packages/slate-tools/tools/webpack/style-tags.html
+++ b/packages/slate-tools/tools/webpack/style-tags.html
@@ -8,7 +8,7 @@
     <% var src = `{{ '${basename}' | asset_url }}` %>
 
     <% if (typeof htmlWebpackPlugin.options.liquidTemplates[chunkName] !== 'undefined') { %>
-      {%- if template.name == '<%= chunkName.split('.')[1] %>' -%}
+      {%- if template == '<%= chunkName.split('.').slice(1).join('.') %>' -%}
         <link type="text/css" href="<%= src %>" rel="stylesheet">
       {%- else -%}
         <link rel="prefetch" href="<%= src %>" as="style">
@@ -25,7 +25,7 @@
 
       <% pages.forEach(function(page){ %>
         <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
-          <% conditions.push("template.name == '" + page.split('.')[1] + "'") %>
+          <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
         <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[page] !== 'undefined') { %>
           <% conditions.push("layout == '" + page.split('.')[1] + "'") %>
         <% } %>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/707

Now when you have: 

- `template/page.liquid`
- `templates/page.alternate.liquid`
- `scripts/templates/page.js`
- `scripts/templates/page.alternate.js`

The following bundles are generated:
- `template.page.js`
- `template.page.alternate.js`

And the following conditions generated in `snippets/style-tags.liquid`:
```
{%- if template == 'product.alternate' -%}
<script type="text/javascript" src="{{ 'template.product.alternate.js' | asset_url }}" defer="defer"></script>
{%- else -%}
<link rel="prefetch" href="{{ 'template.product.alternate.js' | asset_url }}" as="script">
{%- endif -%} 

{%- if template == 'product' -%}
<script type="text/javascript" src="{{ 'template.product.js' | asset_url }}" defer="defer"></script>
{%- else -%}
<link rel="prefetch" href="{{ 'template.product.js' | asset_url }}" as="script">
{%- endif -%}
```

