### PR TITLE
Add configuration to disable external testing using local IP

### DIFF
--- a/packages/slate-tools/cli/prompts/disable-external-testing.js
+++ b/packages/slate-tools/cli/prompts/disable-external-testing.js
@@ -2,11 +2,10 @@
 const chalk = require('chalk');
 const ip = require('ip');
 const inquirer = require('inquirer');
-const slateEnv = require('@shopify/slate-env');
-const {event} = require('@shopify/slate-analytics');
-const {fetchMainThemeId} = require('@shopify/slate-sync');
 const figures = require('figures');
-const {argv} = require('yargs');
+const SlateConfig = require('@shopify/slate-config');
+
+const config = new SlateConfig(require('../../slate-tools.schema'));
 
 const question = {
   type: 'confirm',
@@ -18,7 +17,9 @@ const question = {
 module.exports = async function promptDisableExternalTesting() {
   let address = ip.address();
 
-  if (!ip.isPrivate(address)) {
+  if (!config.get('network.externalTesting')) {
+    address = 'localhost';
+  } else if (!ip.isPrivate(address)) {
     console.log(
       `\n${chalk.yellow(
         figures.warning

--- a/packages/slate-tools/cli/prompts/tests/disable-external-testing.test.js
+++ b/packages/slate-tools/cli/prompts/tests/disable-external-testing.test.js
@@ -1,0 +1,33 @@
+jest.mock('inquirer', () => {
+  return {prompt: jest.fn(() => Promise.resolve({ignoreSettingsData: true}))};
+});
+
+const inquirer = require.requireMock('inquirer');
+
+describe('promptDisableExternalTesting()', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    global.slateUserConfig = {};
+  });
+
+  test(`does not prompt if 'cli.promptSettings' config is set to false`, async () => {
+    const promptDisableExternalTesting = require('../disable-external-testing.js');
+
+    global.slateUserConfig['network.externalTesting'] = false;
+
+    await promptDisableExternalTesting();
+
+    expect(inquirer.prompt).toHaveBeenCalledTimes(0);
+  });
+
+  test(`returns value 'localhost' if 'network.externalTesting' config is set to false`, async () => {
+    const promptDisableExternalTesting = require('../disable-external-testing.js');
+
+    global.slateUserConfig['network.externalTesting'] = false;
+
+    const value = await promptDisableExternalTesting();
+
+    expect(value).toBe('localhost');
+  });
+});

--- a/packages/slate-tools/slate-tools.schema.js
+++ b/packages/slate-tools/slate-tools.schema.js
@@ -21,6 +21,12 @@ module.exports = {
   'eslint.config': (config) =>
     path.resolve(config.get('paths.theme'), '.eslintrc'),
 
+  // Slate will reference files using your local IP address instead of localhost.
+  // This is mostly to get around SSL complications when trying to preview
+  // your development store from an external device like your phone. Use this
+  // config if you want to disable using your local IP and external testing.
+  'network.externalTesting': true,
+
   // Default port used for asset server. If it is not available, the next port
   // that is available is used.
   'network.startPort': 3000,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fix #757 

Adds `'network.externalTesting'` config which will toggle using localhost or your local IP for referencing development assets. If you use localhost, you will probably encounter problems with SSL authentication when visiting your dev shop from an external device.
