### PR TITLE
Ignore copying .DS_Store on build

### DIFF
--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -136,6 +136,7 @@ module.exports = {
       [
         {
           from: config.get('paths.theme.src.svgs'),
+          ignore: ['.DS_Store'],
           to: `${config.get('paths.theme.dist.snippets')}/[name].liquid`,
         },
         {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #708 

Ignores `.DS_Store` files when copying SVGs to the snippets folder

