### PR TITLE
Allow for subdirectories in `snippets/` and `sections/`

### DIFF
--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -104,12 +104,28 @@ module.exports = {
         test: /\.(liquid|json)$/,
         exclude: [
           new RegExp('assets/styles'),
+          new RegExp('sections'),
+          new RegExp('snippets'),
           ...config.get('webpack.commonExcludes'),
         ],
         loader: 'file-loader',
         options: {
           name: '../[path][name].[ext]',
         },
+      },
+      {
+        test: /snippets\/.*\.liquid$/,
+        loader: 'file-loader',
+        options: {
+          name: `../snippets/[name].[ext]`,
+        }
+      },
+      {
+        test: /sections\/.*\.liquid$/,
+        loader: 'file-loader',
+        options: {
+          name: `../sections/[name].[ext]`,
+        }
       },
       {
         test: /assets\/static\//,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Allow for subdirectories to be used in the `snippets/` and `sections/` directories by updating the `core.js` webpack config in `slate-tools` to use a separate a file-loader rule when dealing with these two directories.

The resolution order for how namespace collisions are handled is done alphabetically by directory name, and from topmost directory to bottom. For example:

- `sections/test.liquid` beats `sections/aaa/test.liquid`
- `sections/zzz/test.liquid` beats `sections/aaa/test.liquid`
- `sections/zzz/zzz/test.liquid` beats `sections/zzz/aaa/test.liquid`
- `sections/zzz/test.liquid` beats `sections/zzz/zzz/test.liquid`

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/289

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

