### PR TITLE
Fix `.css` import errors

### DIFF
--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -88,6 +88,10 @@ module.exports = {
         loader: 'hmr-alamo-loader',
       },
       {
+        test: /\.css$/,
+        use: [ 'style-loader', 'css-loader' ]
+      },
+      {
         test: /fonts\/.*\.(eot|svg|ttf|woff|woff2|otf)$/,
         exclude: /node_modules/,
         loader: 'file-loader',


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

When you try to import any `.css` file in `.js` files via `node_module` like this: 

`import 'animate.css/animate.css';`

You get hit with an error like this: 

```bash
ERROR in ../node_modules/animate.css/animate.css
Module parse failed: Unexpected character '@' (1:0)
You may need an appropriate loader to handle this file type.
| @charset "UTF-8";
|
| /*!
 @ ./assets/scripts/layout/theme.js 4:0-33
```

I've followed [webpack css loader usage](https://github.com/webpack-contrib/css-loader#usage).

[A PR was opened 3 months ago](https://github.com/Shopify/slate/pull/682), lots of work has been going on since - rebasing didn't seem to work so re-opening this one

