### PR TITLE
=Add custom deploy script on slate-tools to run pre-run a build scrip…

### DIFF
--- a/packages/slate-analytics/index.js
+++ b/packages/slate-analytics/index.js
@@ -3,10 +3,10 @@ const clearConsole = require('react-dev-utils/clearConsole');
 const rc = require('@shopify/slate-rc');
 const slateEnv = require('@shopify/slate-env');
 const axios = require('axios');
+const argv = require('yargs').argv;
 const prompt = require('./prompt');
 const {validateEmail} = require('./utils');
 const packageJson = require('./package.json');
-const argv = require('yargs').argv;
 
 async function init() {
   let config = rc.get() || rc.generate();

--- a/packages/slate-analytics/index.js
+++ b/packages/slate-analytics/index.js
@@ -1,11 +1,12 @@
 const uuidGenerator = require('uuid/v4');
 const clearConsole = require('react-dev-utils/clearConsole');
 const rc = require('@shopify/slate-rc');
-const {getUserEmail} = require('@shopify/slate-env');
+const slateEnv = require('@shopify/slate-env');
 const axios = require('axios');
 const prompt = require('./prompt');
 const {validateEmail} = require('./utils');
 const packageJson = require('./package.json');
+const argv = require('yargs').argv;
 
 async function init() {
   let config = rc.get() || rc.generate();
@@ -21,7 +22,10 @@ async function init() {
   ) {
     if (typeof config.tracking === 'undefined') {
       // If new user
-      let email = getUserEmail();
+      // Load environtment variables
+      slateEnv.assign(argv.env);
+      slateEnv.validate();
+      let email = slateEnv.getUserEmail();
 
       if (!validateEmail(email)) {
         const answer = await prompt.forNewConsent();

--- a/packages/slate-analytics/package.json
+++ b/packages/slate-analytics/package.json
@@ -25,7 +25,8 @@
     "inquirer": "^5.0.1",
     "react-dev-utils": "^5.0.0",
     "uuid": "^3.2.1",
-    "word-wrap": "^1.2.3"
+    "word-wrap": "^1.2.3",
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "mock-fs": "^4.4.2",

--- a/packages/slate-env/README.md
+++ b/packages/slate-env/README.md
@@ -26,6 +26,9 @@ SLATE_THEME_ID=
 
 # A list of file patterns to ignore, with each list item separated by ':'
 SLATE_IGNORE_FILES=
+
+# The environment variable key which contains the email of the user to register for Slate analytics
+SLATE_USER_EMAIL=
 ```
 
 # Store / Environment Configuration Tips

--- a/packages/slate-tools/cli/index.js
+++ b/packages/slate-tools/cli/index.js
@@ -19,11 +19,23 @@ async function init() {
 
   switch (script) {
     case 'build':
-    case 'deploy':
     case 'start':
     case 'zip':
     case 'lint':
     case 'format':
+      result = spawn.sync(
+        'node',
+        [require.resolve(`./commands/${script}`)].concat(args),
+        {stdio: 'inherit'},
+      );
+      process.exit(result.status);
+      break;
+    case 'deploy':
+      result = spawn.sync(
+        'node',
+        [require.resolve(`./commands/build`)].concat(args),
+        {stdio: 'inherit'},
+      );
       result = spawn.sync(
         'node',
         [require.resolve(`./commands/${script}`)].concat(args),


### PR DESCRIPTION
…t. Update slate-analitycs to load the environment passed in the arguments. Update readme file to add SLATE_USER_EMAIL variable

### What are you trying to accomplish with this PR?

Trying to fix issue #804 


### Checklist
For contributors:
- [ ] I have [updated the readme](https://github.com/Shopify/slate/tree/master/packages/slate-env) to add SLATE_USER_EMAIL variable.

For maintainers:
- [ ] I have added a custom 'deploy' task in packages/slate-tools/cli/index.js to run a build before the deploy. This is to be able to remove the multitasks in the [package.json](https://github.com/Shopify/starter-theme/blob/master/package.json) on the Starter Theme. This is because yarn can only append the arguments to the last script, so in the case of deploy, the first script before the &&:
```
slate-tools build
```

Will not load the --env=qa data.

- [] I have updated the index.js file in slate-analytics to load correctly the slateEnv, In my case, the getUserEmail() was never loading the email in the environmnet file see #804 

-[] For this fix it is also important to update https://github.com/Shopify/starter-theme, check my pull request https://github.com/Shopify/starter-theme/pull/113


