### PR TITLE
Support customers level template bundles

### DIFF
--- a/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
@@ -58,7 +58,8 @@ module.exports = function() {
         'customers',
         `${name}.js`,
       );
-      if (VALID_LIQUID_TEMPLATES.includes(name) && fs.existsSync(jsFile)) {
+
+      if (isValidTemplate(name) && fs.existsSync(jsFile)) {
         entrypoints[`template.${name}`] = jsFile;
       }
     });

--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -29,6 +29,12 @@
     {%- else -%}
       <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
+  <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk].includes('customers/')) { %>
+    {%- if template == 'customers/<%= chunk.split('.').slice(1).join('.') %>' -%}
+      <script type="text/javascript" src="<%= src %>" defer></script>
+    {%- else -%}
+      <link rel="prefetch" href="<%= src %>" as="script">
+    {%- endif -%}
   <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
     {%- if template == '<%= chunk.split('.').slice(1).join('.') %>' -%}
       <script type="text/javascript" src="<%= src %>" defer></script>

--- a/packages/slate-tools/tools/webpack/script-tags.html
+++ b/packages/slate-tools/tools/webpack/script-tags.html
@@ -18,7 +18,11 @@
 
     <% pages.forEach(function(page){ %>
       <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
-        <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
+        <% if (htmlWebpackPlugin.options.liquidTemplates[page].includes('customers/')) { %>
+          <% conditions.push("template == 'customers/" + page.split('.').slice(1).join('.') + "'") %>
+        <% } else { %>
+          <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
+        <% } %>
       <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[page] !== 'undefined') { %>
         <% conditions.push("layout == '" + page.split('.')[1] + "'") %>
       <% } %>
@@ -29,18 +33,20 @@
     {%- else -%}
       <link rel="prefetch" href="<%= src %>" as="script">
     {%- endif -%}
-  <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk].includes('customers/')) { %>
-    {%- if template == 'customers/<%= chunk.split('.').slice(1).join('.') %>' -%}
-      <script type="text/javascript" src="<%= src %>" defer></script>
-    {%- else -%}
-      <link rel="prefetch" href="<%= src %>" as="script">
-    {%- endif -%}
   <% } else if (typeof htmlWebpackPlugin.options.liquidTemplates[chunk] !== 'undefined') { %>
-    {%- if template == '<%= chunk.split('.').slice(1).join('.') %>' -%}
-      <script type="text/javascript" src="<%= src %>" defer></script>
-    {%- else -%}
-      <link rel="prefetch" href="<%= src %>" as="script">
-    {%- endif -%}
+    <% if (htmlWebpackPlugin.options.liquidTemplates[chunk].includes('customers/')) { %>
+      {%- if template == 'customers/<%= chunk.split('.').slice(1).join('.') %>' -%}
+        <script type="text/javascript" src="<%= src %>" defer></script>
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="script">
+      {%- endif -%}
+    <% } else { %>
+      {%- if template == '<%= chunk.split('.').slice(1).join('.') %>' -%}
+        <script type="text/javascript" src="<%= src %>" defer></script>
+      {%- else -%}
+        <link rel="prefetch" href="<%= src %>" as="script">
+      {%- endif -%}
+    <% } %>
   <% } else { %>
     <script type="text/javascript" src="<%= src %>" defer></script>
   <% } %>

--- a/packages/slate-tools/tools/webpack/style-tags.html
+++ b/packages/slate-tools/tools/webpack/style-tags.html
@@ -1,4 +1,3 @@
-
 <% for (var css in htmlWebpackPlugin.files.css) { %>
   <% var basename = htmlWebpackPlugin.files.css[css].split('/').reverse()[0]; %>
   <% var chunkName = basename.replace('.scss', '').replace('.css', '').replace('.styleLiquid', ''); %>
@@ -8,11 +7,19 @@
     <% var src = `{{ '${basename}' | asset_url }}` %>
 
     <% if (typeof htmlWebpackPlugin.options.liquidTemplates[chunkName] !== 'undefined') { %>
-      {%- if template == '<%= chunkName.split('.').slice(1).join('.') %>' -%}
-        <link type="text/css" href="<%= src %>" rel="stylesheet">
-      {%- else -%}
-        <link rel="prefetch" href="<%= src %>" as="style">
-      {%- endif -%}
+      <% if (htmlWebpackPlugin.options.liquidTemplates[chunkName].includes('customers/')) { %>
+        {%- if template == 'customers/<%= chunkName.split('.').slice(1).join('.') %>' -%}
+          <link type="text/css" href="<%= src %>" rel="stylesheet">
+        {%- else -%}
+          <link rel="prefetch" href="<%= src %>" as="style">
+        {%- endif -%}
+      <% } else { %>
+        {%- if template == '<%= chunkName.split('.').slice(1).join('.') %>' -%}
+          <link type="text/css" href="<%= src %>" rel="stylesheet">
+        {%- else -%}
+          <link rel="prefetch" href="<%= src %>" as="style">
+        {%- endif -%}
+      <% } %>
     <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[chunkName] !== 'undefined') { %>
       {%- if layout == '<%= chunkName.split('.')[1] %>' -%}
         <link type="text/css" href="<%= src %>" rel="stylesheet">
@@ -25,7 +32,11 @@
 
       <% pages.forEach(function(page){ %>
         <% if (typeof htmlWebpackPlugin.options.liquidTemplates[page] !== 'undefined') { %>
-          <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
+          <% if (htmlWebpackPlugin.options.liquidTemplates[page].includes('customers/')) { %>
+            <% conditions.push("template == 'customers/" + page.split('.').slice(1).join('.') + "'") %>
+          <% } else { %>
+            <% conditions.push("template == '" + page.split('.').slice(1).join('.') + "'") %>
+          <% } %>
         <% } else if (typeof htmlWebpackPlugin.options.liquidLayouts[page] !== 'undefined') { %>
           <% conditions.push("layout == '" + page.split('.')[1] + "'") %>
         <% } %>


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

After allowing alternate template bundles in beta.8, the liquid logic included in `script-tags.liquid` snippet to check which bundles to load and which bundles to prefetch, was updated to use `template` from `template.name`. This creates a problem for any template that's included in the `customers/` directory because the value that's used to create the template name in the liquid logic is taken from the chunk inside the webpack plugin. This is a problem because bundles/entry points inside the `customers/` directory are flattened down to the same level as the other files, which produces files like this:

```
template.login.js
template.account.js
template.order.js
```

Those file names are used to create the blocks inside of `script-tags.liquid`. This used to be ok before because if you were on a `customers/` template e.g. login.liquid, `{{ template.name }}` would produce 'login', but now since switching to `{{ template }}` the output has changed to 'customers/login'. The resulting output looks like this:

```
{%- if template == 'login' -%}
    <script type="text/javascript" src="https://10.10.10.239:3001/template.login.js" defer="defer"></script>
{%- else -%}
    <link rel="prefetch" href="https://10.10.10.239:3001/template.login.js" as="script">
{%- endif -%}
```

The problem here is that `template == 'login'` will never evaluate to true, so this bundle will never get loaded. This pull requests alters the `script-tags.html` template to check if the chunk includes `customers/` in its path, and if it does, prepends `customers/` to the template check inside of the liquid logic.

Additionally, after poking around a bit, I noticed that bundles for alternate templates in the `customers/` directory weren't being loaded in due to a conditional inside of `get-template-entrypoints.js`. Templates **not** inside `customers/` are getting run through a new `isValidTemplate` function, but the `customers/` templates are not. As a result, any alternate `customers/` template is not being seen as valid, and thus not being included. This pull request updates `get-template-entrypoints.js` to replace the old valid template check with `isValidTemplate` that allows alternate templates to pass through.

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/806

### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

