### PR TITLE
Add rule to webpack config to handle .css files

### DIFF
--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -56,6 +56,7 @@
     "inquirer": "^5.0.1",
     "ip": "^1.1.5",
     "jest": "22.4.2",
+    "mini-css-extract-plugin": "^0.4.3",
     "minimatch": "^3.0.4",
     "minimist": "1.2.0",
     "node-sass": "^4.7.2",

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -9,6 +9,7 @@ const core = require('./parts/core');
 const babel = require('./parts/babel');
 const entry = require('./parts/entry');
 const sass = require('./parts/sass');
+const css = require('./parts/css');
 
 const getLayoutEntrypoints = require('./utilities/get-layout-entrypoints');
 const getTemplateEntrypoints = require('./utilities/get-template-entrypoints');
@@ -27,6 +28,7 @@ module.exports = merge([
   entry,
   babel,
   sass,
+  css,
   {
     mode: 'development',
 

--- a/packages/slate-tools/tools/webpack/config/parts/css.js
+++ b/packages/slate-tools/tools/webpack/config/parts/css.js
@@ -11,8 +11,8 @@ const part = {
   plugins: [],
 };
 
-const sassRule = {
-  test: /\.s[ac]ss$/,
+const cssRule = {
+  test: /\.css$/,
 };
 
 const styleLoader = {
@@ -24,36 +24,30 @@ const styleLoader = {
 
 const cssLoader = {
   loader: 'css-loader',
-  options: {
-    importLoaders: 2,
-    sourceMap: config.get('webpack.sourceMap.styles'),
-  },
+  // Enabling sourcemaps in styles when using HMR causes style-loader to inject
+  // styles using a <link> tag instead of <style> tag. This causes
+  // a FOUC content, which can cause issues with JS that is reading
+  // the DOM for styles (width, height, visibility) on page load.
+  options: {sourceMap: !isDev},
 };
 
 const postcssLoader = {
   loader: 'postcss-loader',
   options: {
     ident: 'postcss',
-    sourceMap: config.get('webpack.sourceMap.styles'),
+    sourceMap: !isDev,
     plugins: config.get('webpack.postcss.plugins'),
   },
 };
 
 const cssVarLoader = {loader: '@shopify/slate-cssvar-loader'};
 
-const sassLoader = {
-  loader: 'sass-loader',
-  options: {sourceMap: config.get('webpack.sourceMap.styles')},
-};
-
-sassRule.use = [
+cssRule.use = [
   isDev ? styleLoader : MiniCssExtractPlugin.loader,
   cssVarLoader,
   cssLoader,
   postcssLoader,
-  sassLoader,
 ];
-
-part.module.rules.push(sassRule);
+part.module.rules.push(cssRule);
 
 module.exports = part;

--- a/packages/slate-tools/tools/webpack/config/parts/sass.js
+++ b/packages/slate-tools/tools/webpack/config/parts/sass.js
@@ -1,8 +1,8 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const SlateConfig = require('@shopify/slate-config');
 const config = new SlateConfig(require('../../../../slate-tools.schema'));
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDev = process.env.NODE_ENV === 'development';
 
 const part = {
   module: {
@@ -19,7 +19,7 @@ const sassRule = {
 const styleLoader = {
   loader: 'style-loader',
   options: {
-    hmr: isDevelopment,
+    hmr: isDev,
   },
 };
 
@@ -47,21 +47,19 @@ const sassLoader = {
   options: {sourceMap: config.get('webpack.sourceMap.styles')},
 };
 
-const extractStyles = new ExtractTextPlugin({
+const extractStyles = new MiniCssExtractPlugin({
   filename: '[name].css.liquid',
-  allChunks: true,
 });
 
-if (isDevelopment) {
-  sassRule.use = [styleLoader, cssLoader, postcssLoader, sassLoader];
-  part.module.rules.push(sassRule);
-} else {
-  sassRule.use = extractStyles.extract({
-    fallback: styleLoader,
-    use: [cssVarLoader, cssLoader, postcssLoader, sassLoader],
-  });
-  part.module.rules.push(sassRule);
-  part.plugins.push(extractStyles);
-}
+sassRule.use = [
+  isDev ? styleLoader : MiniCssExtractPlugin.loader,
+  cssVarLoader,
+  cssLoader,
+  postcssLoader,
+  sassLoader,
+];
+
+part.module.rules.push(sassRule);
+part.plugins.push(extractStyles);
 
 module.exports = part;

--- a/packages/slate-tools/tools/webpack/config/parts/sass.js
+++ b/packages/slate-tools/tools/webpack/config/parts/sass.js
@@ -13,7 +13,6 @@ const part = {
 
 const sassRule = {
   test: /\.s[ac]ss$/,
-  exclude: config.get('webpack.commonExcludes'),
 };
 
 const styleLoader = {

--- a/packages/slate-tools/tools/webpack/config/prod.js
+++ b/packages/slate-tools/tools/webpack/config/prod.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const SlateConfig = require('@shopify/slate-config');
@@ -13,6 +14,7 @@ const babel = require('./parts/babel');
 const sass = require('./parts/sass');
 const entry = require('./parts/entry');
 const core = require('./parts/core');
+const css = require('./parts/css');
 
 const packageJson = require('../../../package.json');
 const getChunkName = require('../get-chunk-name');
@@ -26,6 +28,7 @@ module.exports = merge([
   entry,
   babel,
   sass,
+  css,
   {
     mode: 'production',
     devtool: 'hidden-source-map',
@@ -47,6 +50,10 @@ module.exports = merge([
     },
 
     plugins: [
+      new MiniCssExtractPlugin({
+        filename: '[name].css.liquid',
+      }),
+
       new CleanWebpackPlugin(['dist'], {
         root: config.get('paths.theme'),
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,6 +289,10 @@ agentkeepalive@^3.3.0:
   dependencies:
     humanize-ms "^1.2.1"
 
+ajv-errors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -7757,6 +7761,14 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+mini-css-extract-plugin@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz#98d60fcc5d228c3e36a9bd15a1d6816d6580beb8"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -10091,6 +10103,14 @@ schema-utils@^0.4.0, schema-utils@^0.4.4, schema-utils@^0.4.5:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
   dependencies:
     ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
+schema-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
 scss-tokenizer@^0.2.3:


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

- Fixes #677 : Adds a rule to the Webpack config to handle importing `.css` files directly from `.js` files. Previously, it was only possible to import `.css` files from inside `.scss` files.
- Fixes #785 : Removes `webpack.commonExcludes` from rule `excludes`. No need to ignore the assets or node_module directories with these rules.
- Fixes #797 : Migrates style rules to use `css-mini-extract-plugin` instead of `extract-text-webpack-plugin`

