### PR TITLE
Fix browser sync ui-external

### DIFF
--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -235,7 +235,6 @@ async function onClientAfterSync() {
 
   console.log();
   console.log(`   The Browsersync control panel is available at:\n`);
-  console.log(`      ${chalk.cyan(urls.get('ui'))} ${chalk.grey('(Local)')}`);
 
   if (devServer.domain !== 'localhost') {
     console.log(

--- a/packages/slate-tools/tools/dev-server/index.js
+++ b/packages/slate-tools/tools/dev-server/index.js
@@ -32,7 +32,7 @@ class DevServer {
       https: {key: getSSLKeyPath(), cert: getSSLCertPath()},
       logLevel: 'silent',
       socket: {
-        domain: `${this.domain}:${this.port}`,
+        domain: `https://${this.domain}:${this.port}`,
       },
       ui: {
         port: this.uiPort,


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Partially fix #761.

Since we're serving from https, the domain needed to be `https` and not `http`.

I suggest we remove the local `ui` link for now until we have a solid solution. The `ui-external` works fine anyways.


### How to tophat these changes
- Run yarn watch
- Visit the external ui URL
- See this : 

<img width="1621" alt="screen shot 2018-10-12 at 11 14 20 am" src="https://user-images.githubusercontent.com/6691035/46877986-1613e000-ce10-11e8-8eca-cbd68289e4ff.png">


