### PR TITLE
Prevent trailing slashes at the end of store URLs

### DIFF
--- a/packages/slate-env/__tests__/index.test.js
+++ b/packages/slate-env/__tests__/index.test.js
@@ -328,6 +328,20 @@ describe('Slate Env', () => {
         );
       });
 
+      test('the store URL environment variable does not end with a trailing slash', () => {
+        ['shop1.myshopify.com', 'shop1.myshopify.com/'].forEach((value) => {
+          setVars(
+            Object.assign({}, TEST_ENV, {
+              [config.get('env.keys.store')]: value,
+            }),
+          );
+          const result = slateEnv.validate();
+          expect(result.errors).toHaveLength(
+            value === 'shop1.myshopify.com/' ? 1 : 0,
+          );
+        });
+      });
+
       test('the store API password environment variable is empty', () => {
         setVars(
           Object.assign({}, TEST_ENV, {

--- a/packages/slate-env/index.js
+++ b/packages/slate-env/index.js
@@ -116,6 +116,12 @@ function _validateStore() {
         `${config.get('env.keys.store')} must be a valid .myshopify.com URL`,
       ),
     );
+  } else if (store.slice(-1) === '/') {
+    errors.push(
+      new Error(
+        `${config.get('env.keys.store')} must not end with a trailing slash`,
+      ),
+    );
   }
 
   return errors;


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Fix #772 by surfacing an error that explicitly points out that store URLs should not include a trailing slash.

### Checklist
For contributors:
- [X] I have made sure that the documentation [mentions not including the trailing slash](https://github.com/Shopify/slate/wiki/3.-Connect-to-your-store#setting-slate_store).

For maintainers:
- [ ] I have :tophat:'d these changes.

