### PR TITLE
Add SSL check script to a convenient yarn command

### DIFF
--- a/bin/ssl-check
+++ b/bin/ssl-check
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+f=~/.localhost_ssl;
+ssl_crt=$f/server.crt
+ssl_key=$f/server.key
+b=$(tput bold)
+c=$(tput sgr0)
+
+local_ip=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
+# local_ip=999.999.999 # (uncomment for testing)
+
+domains=(
+    "localhost"
+    "$local_ip"
+)
+
+if [[ ! -f $ssl_crt ]]; then
+    echo -e "\n🛑  ${b}Couldn't find a Slate SSL certificate:${c}"
+    make_key=true
+elif [[ ! $(openssl x509 -noout -text -in $ssl_crt | grep $local_ip) ]]; then
+    echo -e "\n🛑  ${b}Your IP Address has changed:${c}"
+    make_key=true
+else
+    echo -e "\n✅  ${b}Your IP address is still the same.${c}"
+fi
+
+if [[ $make_key == true ]]; then
+    echo -e "Generating a new Slate SSL certificate...\n"
+    count=$(( ${#domains[@]} - 1))
+    mkcert ${domains[@]}
+
+    # Create Slate's default certificate directory, if it doesn't exist
+    test ! -d $f && mkdir $f
+
+    # It appears mkcert bases its filenames off the number of domains passed after the first one.
+    # This script predicts that filename, so it can copy it to Slate's default location.
+    if [[ $count = 0 ]]; then
+        mv ./localhost.pem $ssl_crt
+        mv ./localhost-key.pem $ssl_key
+    else
+        mv ./localhost+$count.pem $ssl_crt
+        mv ./localhost+$count-key.pem $ssl_key
+    fi
+fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "bootstrap": "yarn install && node_modules/.bin/lerna bootstrap",
     "publish": "node_modules/.bin/lerna publish --exact",
     "changelog": "node_modules/.bin/lerna-changelog",
-    "clean": "node_modules/.bin/lerna clean"
+    "clean": "node_modules/.bin/lerna clean",
+    "dev": "bin/ssl-check && yarn start"
   },
   "devDependencies": {
     "babel-jest": "^22.0.4",


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

The ssl-check script that @callaginn wrote is super useful and fixes the SSL issues I was having as well as others have been having. The current docs say to add this script inside your profile or where your other local scripts reside; however, it would be way more convenient to provide it with the library while it's still needed.

This will require a docs change for sure, but hopefully it will be more deletion than additions.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

