### PR TITLE
Add environment to deploy message

### DIFF
--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -82,7 +82,13 @@ async function deploy(cmd = '', files = []) {
 
   deploying = true;
 
-  console.log(chalk.magenta(`\n${figures.arrowUp}  Uploading to Shopify...\n`));
+  console.log(
+    chalk.magenta(
+      `\n${
+        figures.arrowUp
+      }  Uploading to Shopify on ${slateEnv.getEnvNameValue()} environment...\n`,
+    ),
+  );
 
   try {
     await promiseThemekitConfig();


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Partially fixing #863.

### Problem

When Themekit is deploying on Shopify, it will show progress like this : 

`[environment]: 10 / 30 [=====================>--------------]  33 %`

which works great when you are using the default `config.yml` files. 

Since we are using `.env` files, Themekit doesn't understand that there's multiple environment. So we always show `[development]` even if we are using another environment.

If we try to add the `--env` flag to our [_generateConfigFlags()](https://github.com/Shopify/slate/blob/5c68081db54cd94c79775d02bc10069676e2fde6/packages/slate-sync/index.js#L44), Themekit will complain that there's no 'staging' environment, for example : `staging does not exist in this environments list`.


### Solution

I suggest adding the environment in the `↑  Uploading to Shopify...` message above as a workaround.

The developer will now see : 

```
↑  Uploading to Shopify on staging environment...
[development]: 10 / 30 [=====================>--------------]  33 %
```

I don't think it's perfect, but it works for now.
