### PR TITLE
Add check for hyphens in Liquid style tag for CSS custom properties

### DIFF
--- a/packages/slate-cssvar-loader/index.js
+++ b/packages/slate-cssvar-loader/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const SlateConfig = require('@shopify/slate-config');
 const config = new SlateConfig(require('./slate-cssvar-loader.schema'));
 
-const STYLE_BLOCK_REGEX = /(?:<style>|\{% style %\})([\S\s]*?)(?:<\/style>|\{% endstyle %\})/g;
+const STYLE_BLOCK_REGEX = /(?:<style>|\{%-? style -?%\})([\S\s]*?)(?:<\/style>|\{%-? endstyle -?%\})/g;
 const CSS_VAR_FUNC_REGEX = /var\(--(.*?)\)/g;
 const CSS_VAR_DECL_REGEX = /--(.*?):\s*(\{\{\s*.*?\s*\}\}.*?);/g;
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

This PR adds a check for an optional `-` hyphen character when using the `{%- style -%}...{%- endstyle -%}` Liquid tags to remove whitespace.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.

