### PR TITLE
Fix liquid styles not uploading to Shopify

### DIFF
--- a/packages/slate-tools/tools/asset-server/index.js
+++ b/packages/slate-tools/tools/asset-server/index.js
@@ -62,9 +62,13 @@ module.exports = class DevServer {
   _isChunk(key, chunks) {
     return (
       chunks.filter((chunk) => {
-        return key.indexOf(chunk.id) > -1;
+        return key.indexOf(chunk.id) > -1 && !this._isLiquidStyle(key);
       }).length > 0
     );
+  }
+
+  _isLiquidStyle(key) {
+    return key.indexOf('styleLiquid.scss.liquid') > -1;
   }
 
   _hasAssetChanged(key, asset) {

--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -50,20 +50,12 @@ module.exports = {
       {
         test: /\.(liquid|json)$/,
         exclude: [
-          new RegExp('assets/styles'),
+          /(css|scss|sass)\.liquid$/,
           ...config.get('webpack.commonExcludes'),
         ],
         loader: 'file-loader',
         options: {
           name: '../[path][name].[ext]',
-        },
-      },
-      {
-        test: /assets\/static\//,
-        exclude: /node_modules/,
-        loader: 'file-loader',
-        options: {
-          name: '[name].[ext]',
         },
       },
       {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes https://github.com/Shopify/slate/issues/864, followup #877 

Had another look at this and found the source of the problem.. `liquidStyle` files are not being uploaded to Shopify servers because of some bad filtering on my end. Refining that filtering to exclude liquid styles will make sure its uploaded and you don't get a `MIME type` error.

Also can see the original `scss.liquid` file gets output into `dist` which might cause problems if uploaded to Shopify. 
