### PR TITLE
Updating node-sass to version 4.10.0

### DIFF
--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -59,7 +59,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "minimatch": "^3.0.4",
     "minimist": "1.2.0",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.10.0",
     "ora": "^2.0.0",
     "portscanner": "^2.2.0",
     "postcss-loader": "2.1.1",

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -59,7 +59,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "minimatch": "^3.0.4",
     "minimist": "1.2.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.11.0",
     "ora": "^2.0.0",
     "portscanner": "^2.2.0",
     "postcss-loader": "2.1.1",


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Just trying to fix the error message in the console. I think it's a custom error message because it still pops up, but node-sass has been updated to version 4.10.0 inside the slate-tools package. Is this the only place where that dependency is found?

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/778

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

