### PR TITLE
Fix cli:start and start:start analytics events

### DIFF
--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -34,6 +34,8 @@ let assetServer;
 let devServer;
 let previewUrl;
 
+event('slate-tools:start:start', {version: packageJson.version});
+
 Promise.all([
   getAvailablePortSeries(config.get('network.startPort'), 3),
   promptExternalTesting(),

--- a/packages/slate-tools/cli/index.js
+++ b/packages/slate-tools/cli/index.js
@@ -9,6 +9,7 @@ const packageJson = require('../package.json');
 
 const script = process.argv[2];
 const args = process.argv.slice(3);
+const config = new SlateConfig(require('../slate-tools.schema'));
 
 try {
   slateEnv.assign(argv.env);
@@ -20,10 +21,21 @@ try {
 let result;
 
 async function init() {
+  let slateConfig;
+
   await analytics.init();
 
+  // Convert user config to JSON string so it can be sent in analytics. Make sure
+  // we catch any errors while converting, such as converting a circular object
+  // structure to JSON
+  try {
+    slateConfig = JSON.stringify(config.userConfig);
+  } catch (error) {
+    slateConfig = JSON.stringify({error: error.message});
+  }
+
   analytics.event('slate-tools:cli:start', {
-    slateConfig: SlateConfig.userConfig,
+    slateConfig,
     version: packageJson.version,
   });
 


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #920, fixes #921 

Adds back a trigger for the `'slate-tools:start:start'` event and makes sure we're actually passing user config data to `'slate-tools:cli:start'`.
