### PR TITLE
Hide Shopify preview bar

### DIFF
--- a/packages/slate-tools/tools/dev-server/index.js
+++ b/packages/slate-tools/tools/dev-server/index.js
@@ -22,8 +22,9 @@ class DevServer {
         middleware: (req, res, next) => {
           // Shopify sites with redirection enabled for custom domains force redirection
           // to that domain. `?_fd=0` prevents that forwarding.
+          // ?pb=0 hides the Shopify preview bar
           const prefix = req.url.indexOf('?') > -1 ? '&' : '?';
-          const queryStringComponents = ['_fd=0'];
+          const queryStringComponents = ['_fd=0&pb=0'];
 
           req.url += prefix + queryStringComponents.join('&');
           next();


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fix #653, #796, #637, #420.

Shopify team just released a [parameter to hide the preview bar](https://github.com/Shopify/shopify/pull/184056) when previewing a theme.

Let's add the parameter to the URL by default to hide the bar and fixes the issues above.

