### PR TITLE
Now sections can have separate .json file for schema.

### DIFF
--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -4,6 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const SlateConfig = require('@shopify/slate-config');
 const config = new SlateConfig(require('../../../../slate-tools.schema'));
+const injectSchemasToSections = require('../utilities/inject-schemas-to-sections');
 
 const extractLiquidStyles = new ExtractTextPlugin(
   '[name].styleLiquid.scss.liquid',
@@ -94,6 +95,10 @@ module.exports = {
       {
         from: config.get('paths.theme.src.sections'),
         to: config.get('paths.theme.dist.sections'),
+        ignore: [ '*.schema.json' ],
+        transform (content, path) {
+          return injectSchemasToSections(content,path);
+        }
       },
       {
         from: config.get('paths.theme.src.snippets'),

--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -96,7 +96,7 @@ module.exports = {
         from: config.get('paths.theme.src.sections'),
         to: config.get('paths.theme.dist.sections'),
         ignore: ['*.schema.json'],
-        transform (content, pathToFile) {
+        transform(content, pathToFile) {
           return injectSchemasToSections(content, pathToFile);
         },
       },

--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -95,10 +95,10 @@ module.exports = {
       {
         from: config.get('paths.theme.src.sections'),
         to: config.get('paths.theme.dist.sections'),
-        ignore: [ '*.schema.json' ],
-        transform (content, path) {
-          return injectSchemasToSections(content,path);
-        }
+        ignore: ['*.schema.json'],
+        transform (content, pathToFile) {
+          return injectSchemasToSections(content, pathToFile);
+        },
       },
       {
         from: config.get('paths.theme.src.snippets'),

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -2,21 +2,19 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = function(content, liquidFilePath) {
-
   let transformedContent = content.toString();
 
   // naming convention is : section_name.schema.json for separate json schema files.
   const jsonSchemaFilePath = liquidFilePath.replace('.liquid', '.schema.json');
 
   // to check if we already have defined {% schema %} in content
-  const schemaTagExistsInFileRegex = /{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gmi;
+  const schemaTagExistsInFileRegex = /{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gim;
   // check for {% inject 'file.schema.json' %}
-  const injectorRegex = /{%\s+inject\s+['"]([^'"]+)['"]\s*%}/gmi;
+  const injectorRegex = /{%\s+inject\s+['"]([^'"]+)['"]\s*%}/gim;
   const schemaTagExists = transformedContent.match(schemaTagExistsInFileRegex);
 
   // lets check if schema file exists and
   if (fs.existsSync(jsonSchemaFilePath)) {
-
     if (schemaTagExists) {
       // do nothing maybe warn about to inject it with {% inject 'file.json' %}
     } else {
@@ -62,7 +60,10 @@ module.exports = function(content, liquidFilePath) {
       const injectedFileName = injectorMatch[1];
 
       if (injectorTagToReplace && injectedFileName) {
-        const fileToInjectPath = path.resolve(path.dirname(liquidFilePath), injectedFileName);
+        const fileToInjectPath = path.resolve(
+          path.dirname(liquidFilePath),
+          injectedFileName,
+        );
 
         if (fs.existsSync(fileToInjectPath)) {
           const injectedFileContent = fs.readFileSync(fileToInjectPath, 'utf8');
@@ -70,7 +71,10 @@ module.exports = function(content, liquidFilePath) {
           console.log(
             `Injecting ${fileToInjectPath} to ${liquidFilePath} at ${injectorTagToReplace}`,
           );
-          transformedContent = transformedContent.replace(injectorTagToReplace, injectedFileContent);
+          transformedContent = transformedContent.replace(
+            injectorTagToReplace,
+            injectedFileContent,
+          );
 
         } else {
           console.warn(
@@ -79,11 +83,9 @@ module.exports = function(content, liquidFilePath) {
         }
       }
     }
-
   }
 
 
   // return content untouched if schema is already defined in it. or we don't have separate json file, or there's no {% inject 'filename' %}
   return transformedContent;
-
 };

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -1,49 +1,46 @@
 const fs = require('fs');
 
 module.exports = function(content, path) {
-
-    // naming convention is : section_name.schema.json for separate json schema files.
-    const jsonSchemaFilePath = path.replace('.liquid', '.schema.json');
-
-    // lets check if schema file exists and 
-
-    if(fs.existsSync(jsonSchemaFilePath)){
+  // naming convention is : section_name.schema.json for separate json schema files.
+  const jsonSchemaFilePath = path.replace('.liquid', '.schema.json');
+  let transformedContent = content;
+  // lets check if schema file exists and
+  if (fs.existsSync(jsonSchemaFilePath)) {
     
-        console.log(`Found separate section schema for: ${path}`);
-
-        content = content.toString();
-
-        // and check if we already have defined {% schema %} in content
-        if(!content.match(/{\%\s*schema\s*\%}([\s\S]+){\%\s*endschema\s*\%}/gmi)){
-
-            try{
-            const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
-                            
-            console.log(`Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`);
+    console.log(`Found separate section schema for: ${path}`);
     
-                if(jsonSchema){
-                    content = 
+    transformedContent = content.toString();
+
+    // and check if we already have defined {% schema %} in content
+    if (!content.match(/{\%\s*schema\s*\%}([\s\S]+){\%\s*endschema\s*\%}/gmi)) {
+      try {
+        const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
+        
+        console.log(`Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`);
+        
+        if (jsonSchema) {
+          content =
 `${content}
 {% schema %}
   ${jsonSchema}
 {% endschema %}
 `;
-                }else{
-                    console.warn(` No Schema defined for Section at: ${path}`);  
-                }
-            }catch(e){
-                console.warn(e,` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`);
-            }
-      }else{
-        console.warn(`!----------------------------------------------------------! `);
-        console.warn(` You have json schema file: ${jsonSchemaFilePath} for ${path} `);
-        console.warn(` but it contains {% schema %}...{% endschema %} declaration`);
-        console.warn(` please remove it from ${path} `);
-        console.warn(` to allow me to inject schema from separate .schema.json file `);
-        console.warn(`------------------------------------------------------------ `);
+        }else{
+          console.warn(` No Schema defined for Section at: ${path}`);
+        }
+      }catch(e){
+        console.warn(e,` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`);
       }
+    }else{
+      console.warn(`!----------------------------------------------------------! `);
+      console.warn(` You have json schema file: ${jsonSchemaFilePath} for ${path} `);
+      console.warn(` but it contains {% schema %}...{% endschema %} declaration`);
+      console.warn(` please remove it from ${path} `);
+      console.warn(` to allow me to inject schema from separate .schema.json file `);
+      console.warn(`------------------------------------------------------------ `);
     }
-    // return content untouched if schema is already defined in it. or we don't have separate json file
-    return content;
+  }
+  // return content untouched if schema is already defined in it. or we don't have separate json file
+  return transformedContent;
 
 }

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 module.exports = function(content, path) {
 
     // naming convention is : section_name.schema.json for separate json schema files.
-    const jsonShemaFilePath = path.replace('.liquid','.schema.json');
+    const jsonSchemaFilePath = path.replace('.liquid', '.schema.json');
 
     // lets check if schema file exists and 
 

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -1,25 +1,33 @@
 const fs = require('fs');
+const path = require('path');
 
-module.exports = function(content, path) {
+module.exports = function(content, liquidFilePath) {
+
+  let transformedContent = content.toString();
+
   // naming convention is : section_name.schema.json for separate json schema files.
-  const jsonSchemaFilePath = path.replace('.liquid', '.schema.json');
-  let transformedContent = content;
+  const jsonSchemaFilePath = liquidFilePath.replace('.liquid', '.schema.json');
+
+  // to check if we already have defined {% schema %} in content
+  const schemaTagExistsInFileRegex = /{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gmi;
+  // check for {% inject 'file.schema.json' %}
+  const injectorRegex = /{%\s+inject\s+['"]([^'"]+)['"]\s*%}/gmi;
+  const schemaTagExists = transformedContent.match(schemaTagExistsInFileRegex);
+
   // lets check if schema file exists and
   if (fs.existsSync(jsonSchemaFilePath)) {
 
-    console.log(`Found separate section schema for: ${path}`);
-    
-    transformedContent = content.toString();
-
-    // and check if we already have defined {% schema %} in content
-    if (!(transformedContent.match(/{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gim))) {
+    if (schemaTagExists) {
+      // do nothing maybe warn about to inject it with {% inject 'file.json' %}
+    } else {
       try {
         const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
 
         console.log(
-          `Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`
+          `Found separate section schema for: ${liquidFilePath}`,
+          `Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${liquidFilePath}`,
         );
-        
+
         if (jsonSchema) {
           transformedContent =
 `${transformedContent}
@@ -27,37 +35,55 @@ module.exports = function(content, path) {
   ${jsonSchema}
 {% endschema %}
 `;
-        }else{
-          console.warn(` No Schema defined for Section at: ${path}`);
+        } else {
+          console.warn(` No Schema defined for Section at: ${liquidFilePath}`);
         }
-      }catch(exceptionObj){
+      } catch (exceptionObj) {
         console.warn(
           exceptionObj,
-          ` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`
+          ` Error reading  json schema file: ${jsonSchemaFilePath} for ${liquidFilePath}`,
         );
       }
-    }else{
-      console.warn(
-        `!----------------------------------------------------------! `
-      );
-      console.warn(
-        ` You have json schema file: ${jsonSchemaFilePath} for ${path} `
-      );
-      console.warn(
-        ` but it contains {% schema %}...{% endschema %} declaration`
-      );
-      console.warn(
-        ` please remove it from ${path} `)
-      ;
-      console.warn(
-        ` to allow me to inject schema from separate .schema.json file `
-      );
-      console.warn(
-        `------------------------------------------------------------ `
-      );
     }
   }
-  // return content untouched if schema is already defined in it. or we don't have separate json file
+
+  // lets inject all we want here :)
+  if (transformedContent.match(injectorRegex)) {
+    // lets check if injected file exists and inject it if needed
+    let injectorMatch;
+
+    while ((injectorMatch = injectorRegex.exec(transformedContent)) !== null) {
+      // This is necessary to avoid infinite loops with zero-width matches
+      if (injectorMatch.index === injectorRegex.lastIndex) {
+        injectorRegex.lastIndex++;
+      }
+      // run over inject commands and inject files
+      const injectorTagToReplace = injectorMatch[0];
+      const injectedFileName = injectorMatch[1];
+
+      if (injectorTagToReplace && injectedFileName) {
+        const fileToInjectPath = path.resolve(path.dirname(liquidFilePath), injectedFileName);
+
+        if (fs.existsSync(fileToInjectPath)) {
+          const injectedFileContent = fs.readFileSync(fileToInjectPath, 'utf8');
+
+          console.log(
+            `Injecting ${fileToInjectPath} to ${liquidFilePath} at ${injectorTagToReplace}`,
+          );
+          transformedContent = transformedContent.replace(injectorTagToReplace, injectedFileContent);
+
+        } else {
+          console.warn(
+            ` Inject command in ${liquidFilePath} can't find file to inject at ${fileToInjectPath}`,
+          );
+        }
+      }
+    }
+
+  }
+
+
+  // return content untouched if schema is already defined in it. or we don't have separate json file, or there's no {% inject 'filename' %}
   return transformedContent;
 
 };

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -19,7 +19,7 @@ module.exports = function(content, path) {
             try{
             const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
                             
-            console.log(`Injecting JSON Shema ${jsonShemaFilePath}  to Section at ${path}`);
+            console.log(`Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`);
     
                 if(jsonSchema){
                     content = 

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -17,7 +17,7 @@ module.exports = function(content, path) {
         if(!content.match(/{\%\s*schema\s*\%}([\s\S]+){\%\s*endschema\s*\%}/gmi)){
 
             try{
-            const jsonSchema = fs.readFileSync(jsonShemaFilePath, 'utf8');
+            const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
                             
             console.log(`Injecting JSON Shema ${jsonShemaFilePath}  to Section at ${path}`);
     

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -5,7 +5,7 @@ module.exports = function(content, path) {
     // naming convention is : section_name.schema.json for separate json schema files.
     const jsonShemaFilePath = path.replace('.liquid','.schema.json');
 
-    // lets check if shema file exists and 
+    // lets check if schema file exists and 
 
     if(fs.existsSync(jsonSchemaFilePath)){
     

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -27,8 +27,7 @@ module.exports = function(content, liquidFilePath) {
         );
 
         if (jsonSchema) {
-          transformedContent =
-`${transformedContent}
+          transformedContent = `${transformedContent}
 {% schema %}
   ${jsonSchema}
 {% endschema %}
@@ -75,7 +74,6 @@ module.exports = function(content, liquidFilePath) {
             injectorTagToReplace,
             injectedFileContent,
           );
-
         } else {
           console.warn(
             ` Inject command in ${liquidFilePath} can't find file to inject at ${fileToInjectPath}`,
@@ -84,7 +82,6 @@ module.exports = function(content, liquidFilePath) {
       }
     }
   }
-
 
   // return content untouched if schema is already defined in it. or we don't have separate json file, or there's no {% inject 'filename' %}
   return transformedContent;

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -12,7 +12,7 @@ module.exports = function(content, path) {
     transformedContent = content.toString();
 
     // and check if we already have defined {% schema %} in content
-    if (!(content.match(/{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gim))) {
+    if (!(transformedContent.match(/{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gim))) {
       try {
         const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
 

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -36,7 +36,7 @@ module.exports = function(content, path) {
             }
       }else{
         console.warn(`!----------------------------------------------------------! `);
-        console.warn(` You have json shema file: ${jsonShemaFilePath} for ${path} `);
+        console.warn(` You have json schema file: ${jsonSchemaFilePath} for ${path} `);
         console.warn(` but it contains {% schema %}...{% endschema %} declaration`);
         console.warn(` please remove it from ${path} `);
         console.warn(` to allow me to inject schema from separate .schema.json file `);

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -6,21 +6,23 @@ module.exports = function(content, path) {
   let transformedContent = content;
   // lets check if schema file exists and
   if (fs.existsSync(jsonSchemaFilePath)) {
-    
+
     console.log(`Found separate section schema for: ${path}`);
     
     transformedContent = content.toString();
 
     // and check if we already have defined {% schema %} in content
-    if (!content.match(/{\%\s*schema\s*\%}([\s\S]+){\%\s*endschema\s*\%}/gmi)) {
+    if (!(content.match(/{%\s*schema\s*%}([\s\S]+){%\s*endschema\s*%}/gim))) {
       try {
         const jsonSchema = fs.readFileSync(jsonSchemaFilePath, 'utf8');
-        
-        console.log(`Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`);
+
+        console.log(
+          `Injecting JSON Schema ${jsonSchemaFilePath}  to Section at ${path}`
+        );
         
         if (jsonSchema) {
-          content =
-`${content}
+          transformedContent =
+`${transformedContent}
 {% schema %}
   ${jsonSchema}
 {% endschema %}
@@ -28,19 +30,34 @@ module.exports = function(content, path) {
         }else{
           console.warn(` No Schema defined for Section at: ${path}`);
         }
-      }catch(e){
-        console.warn(e,` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`);
+      }catch(exceptionObj){
+        console.warn(
+          exceptionObj,
+          ` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`
+        );
       }
     }else{
-      console.warn(`!----------------------------------------------------------! `);
-      console.warn(` You have json schema file: ${jsonSchemaFilePath} for ${path} `);
-      console.warn(` but it contains {% schema %}...{% endschema %} declaration`);
-      console.warn(` please remove it from ${path} `);
-      console.warn(` to allow me to inject schema from separate .schema.json file `);
-      console.warn(`------------------------------------------------------------ `);
+      console.warn(
+        `!----------------------------------------------------------! `
+      );
+      console.warn(
+        ` You have json schema file: ${jsonSchemaFilePath} for ${path} `
+      );
+      console.warn(
+        ` but it contains {% schema %}...{% endschema %} declaration`
+      );
+      console.warn(
+        ` please remove it from ${path} `)
+      ;
+      console.warn(
+        ` to allow me to inject schema from separate .schema.json file `
+      );
+      console.warn(
+        `------------------------------------------------------------ `
+      );
     }
   }
   // return content untouched if schema is already defined in it. or we don't have separate json file
   return transformedContent;
 
-}
+};

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+
+module.exports = function(content, path) {
+
+    // naming convention is : section_name.schema.json for separate json schema files.
+    const jsonShemaFilePath = path.replace('.liquid','.schema.json');
+
+    // lets check if shema file exists and 
+
+    if(fs.existsSync(jsonShemaFilePath)){
+    
+        console.log(`Found separate section schema for: ${path}`);
+
+        content = content.toString();
+
+        // and check if we already have defined {% schema %} in content
+        if(!content.match(/{\%\s*schema\s*\%}([\s\S]+){\%\s*endschema\s*\%}/gmi)){
+
+            try{
+            const jsonSchema = fs.readFileSync(jsonShemaFilePath, 'utf8');
+                            
+            console.log(`Injecting JSON Shema ${jsonShemaFilePath}  to Section at ${path}`);
+    
+                if(jsonSchema){
+                    content = 
+`${content}
+{% schema %}
+  ${jsonSchema}
+{% endschema %}
+`;
+                }else{
+                    console.warn(` No Schema defined for Section at: ${path}`);  
+                }
+            }catch(e){
+                console.warn(e,` Error reading  json shema file: ${jsonShemaFilePath} for ${path}`);
+            }
+      }else{
+        console.warn(`!----------------------------------------------------------! `);
+        console.warn(` You have json shema file: ${jsonShemaFilePath} for ${path} `);
+        console.warn(` but it contains {% schema %}...{% endschema %} declaration`);
+        console.warn(` please remove it from ${path} `);
+        console.warn(` to allow me to inject schema from separate .schema.json file `);
+        console.warn(`------------------------------------------------------------ `);
+      }
+    }
+    // return content untouched if schema is already defined in it. or we don't have separate json file
+    return content;
+
+}

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -7,7 +7,7 @@ module.exports = function(content, path) {
 
     // lets check if shema file exists and 
 
-    if(fs.existsSync(jsonShemaFilePath)){
+    if(fs.existsSync(jsonSchemaFilePath)){
     
         console.log(`Found separate section schema for: ${path}`);
 

--- a/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/inject-schemas-to-sections.js
@@ -32,7 +32,7 @@ module.exports = function(content, path) {
                     console.warn(` No Schema defined for Section at: ${path}`);  
                 }
             }catch(e){
-                console.warn(e,` Error reading  json shema file: ${jsonShemaFilePath} for ${path}`);
+                console.warn(e,` Error reading  json schema file: ${jsonSchemaFilePath} for ${path}`);
             }
       }else{
         console.warn(`!----------------------------------------------------------! `);


### PR DESCRIPTION
## Now sections can have separate .json file for schema.


If  we have `section_name.schema.json` file in same directory as `section_name.liquid` file  it will inject it as a `{% schema %}` for this section while placing it  in `/dist/sections` directory.

It checks if `section_name.liquid` has inline definition and does nothing if it has it inline.
If `section_name.liquid` don't have neither `section_name.schema.json` neither inline `{% schema %}` declaration in it, it outputs a warning.

The win of this approach is simplifying json editing leading to less errors in schema declaration. Also you have good syntax highlighting in editor of choice for .json files for sure.

https://github.com/Shopify/slate/issues/749
https://github.com/Shopify/slate/issues/856


### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

