### PR TITLE
Expose request timeout of themekit in .env

### DIFF
--- a/docs/v1/versioned_docs/version-1.0.0-beta.14/connect-to-your-store.md
+++ b/docs/v1/versioned_docs/version-1.0.0-beta.14/connect-to-your-store.md
@@ -18,8 +18,11 @@ SLATE_PASSWORD=ccf7fb19ed4dc6993ac6355c0c489c7c7
 # The ID of the theme you wish to upload files to
 SLATE_THEME_ID=32112656003
 
-# A list of file patterns to ignore, with each list item separated by ':'
+# A list of file patterns to ignore, with each list item separated by ':' (optional)
 SLATE_IGNORE_FILES=config/settings_data.json
+
+# The timeout for upload theme (optional)
+SLATE_TIMEOUT=2m
 ```
 
 ## Setting SLATE_STORE
@@ -50,12 +53,20 @@ Each theme entry will have an `id` tag. Set the `SLATE_THEME_ID` to the theme ID
 
 ## Setting SLATE_IGNORE_FILES
 
-This is the only optional setting in the `.env` file and it enables you to ignore certain files from being deployed to your Shopify store. One example would be to ignore the `settings_data.json` file to avoid overwriting your theme’s section settings every time you deploy your theme.
+This setting enables you to ignore certain files from being deployed to your Shopify store. One example would be to ignore the `settings_data.json` file to avoid overwriting your theme’s section settings every time you deploy your theme.
 
 The file paths are relative to the theme’s `dist/` directory so ignoring the `settings_data.json` file would look like the following:
 
 ```bash
 SLATE_IGNORE_FILES=config/settings_data.json
+```
+
+## Setting SLATE_TIMEOUT
+
+Request timeout. If you have larger files in your project that may take longer than the default 30s to upload, you may want to increase this value. You can set this value to 60s for seconds or 1m for one minute. [Themekit request timeout configuration](https://github.com/Shopify/themekit/blob/master/docs/configuration/index.md#theme-kit-configuration)
+
+```bash
+SLATE_TIMEOUT=2m
 ```
 
 ## Creating an alternative `.env` file

--- a/packages/slate-env/__tests__/index.test.js
+++ b/packages/slate-env/__tests__/index.test.js
@@ -19,6 +19,7 @@ const TEST_ENV = {
   [config.get('env.keys.themeId')]: '987654321',
   [config.get('env.keys.ignoreFiles')]: 'config/settings_data.json',
   [config.get('env.keys.userEmail')]: 'test@email.com',
+  [config.get('env.keys.timeout')]: '60s',
 };
 
 function setVars(vars) {

--- a/packages/slate-env/index.js
+++ b/packages/slate-env/index.js
@@ -10,6 +10,7 @@ const SLATE_ENV_VARS = [
   config.get('env.keys.password'),
   config.get('env.keys.themeId'),
   config.get('env.keys.ignoreFiles'),
+  config.get('env.keys.timeout'),
   config.get('env.keys.userEmail'),
 ];
 
@@ -231,6 +232,11 @@ function getIgnoreFilesValue() {
   return typeof value === 'undefined' ? '' : value;
 }
 
+function getTimeoutValue() {
+  const value = process.env[config.get('env.keys.timeout')];
+  return typeof value === 'undefined' ? '' : value;
+}
+
 function getUserEmail() {
   const value = process.env[config.get('env.keys.userEmail')];
   return typeof value === 'undefined' ? '' : value;
@@ -249,5 +255,6 @@ module.exports = {
   getPasswordValue,
   getThemeIdValue,
   getIgnoreFilesValue,
+  getTimeoutValue,
   getUserEmail,
 };

--- a/packages/slate-env/slate-env.schema.js
+++ b/packages/slate-env/slate-env.schema.js
@@ -43,4 +43,8 @@ module.exports = {
   // The environment variable key which contains the email of the user to
   // register for Slate analytics
   'env.keys.userEmail': 'SLATE_USER_EMAIL',
+
+  // The environment variable key which contains the timeout of themekit upload
+  // Timeout upload is
+  'env.keys.timeout': 'SLATE_TIMEOUT',
 };

--- a/packages/slate-sync/index.js
+++ b/packages/slate-sync/index.js
@@ -50,6 +50,9 @@ function _generateConfigFlags() {
     '--store': slateEnv.getStoreValue(),
     '--env': slateEnv.getEnvNameValue(),
   };
+  if (slateEnv.getTimeoutValue()) {
+    flags['--timeout'] = slateEnv.getTimeoutValue();
+  }
 
   // Convert object to key value pairs and flatten the array
   return Array.prototype.concat(...Object.entries(flags));


### PR DESCRIPTION
This PR  expose the request timeout optional setting of themekit in the .env of slate.

A `.env` at the root such as:

```
SLATE_STORE=***.myshopify.com
SLATE_PASSWORD=***
SLATE_THEME_ID=***
SLATE_IGNORE_FILES=config/settings_data.json
SLATE_TIMEOUT=2m
```

will set the `timeout`  in `config.yml` at `2m` `SLATE_TIMEOUT` used by themekit.

This closes #831, fixes #699 and maybe some others I didn't saw.

### Checklist
For contributors:
- [x] I have updated the documentation
- [x] New `.env` setting exposing themekit `timeout`

For maintainers:
- No major update

This is my first PR on Slate and maybe I'm not aware of everything in the project. I needed to modify the timeout for my own and saw some issues on this.