### PR TITLE
Upgrade to node-sass@4.11.0

### DIFF
--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -59,7 +59,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "minimatch": "^3.0.4",
     "minimist": "1.2.0",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.10.0",
     "ora": "^2.0.0",
     "portscanner": "^2.2.0",
     "postcss-loader": "2.1.1",

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -59,7 +59,7 @@
     "mini-css-extract-plugin": "^0.4.3",
     "minimatch": "^3.0.4",
     "minimist": "1.2.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.11.0",
     "ora": "^2.0.0",
     "portscanner": "^2.2.0",
     "postcss-loader": "2.1.1",


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

## Continuation of [this PR](https://github.com/Shopify/slate/pull/899)

The point of PR #899 was to update the `slate-tools` package's dependencies to include `node-sass 4.10.0`, but, as @t-kelly pointed out, [`node-sass 4.11.0` is a stable release](https://www.npmjs.com/package/node-sass) and is probably more reliable.

*Please provide a link to the associated GitHub issue.*
[#778](https://github.com/Shopify/slate/issues/778)

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

