### PR TITLE
Add the sections folder back to webpack context

### DIFF
--- a/packages/slate-sections-plugin/__tests__/index.test.js
+++ b/packages/slate-sections-plugin/__tests__/index.test.js
@@ -9,7 +9,6 @@ test('sections with no seperate schemas, with liquid files that just need to be 
   const stats = await compiler('fixtures/startersections/');
   const expectedAssetOutputKey = '../sections/test-section.liquid';
 
-  debugger;
   // Ensure sections is in context
   expect(
     stats.compilation.contextDependencies.has(

--- a/packages/slate-sections-plugin/__tests__/index.test.js
+++ b/packages/slate-sections-plugin/__tests__/index.test.js
@@ -7,8 +7,16 @@ jest.unmock('fs-extra');
 
 test('sections with no seperate schemas, with liquid files that just need to be copied over', async () => {
   const stats = await compiler('fixtures/startersections/');
-
   const expectedAssetOutputKey = '../sections/test-section.liquid';
+
+  debugger;
+  // Ensure sections is in context
+  expect(
+    stats.compilation.contextDependencies.has(
+      path.resolve(__dirname, 'fixtures/startersections/sections'),
+    ),
+  ).toBeTruthy();
+
   expect(
     stats.compilation.assets[expectedAssetOutputKey]._value,
   ).toMatchSnapshot();
@@ -29,6 +37,14 @@ test('sections with no seperate schemas, with liquid files that just need to be 
 test('section that has template living in folders with schema.json and no locales', async () => {
   const stats = await compiler('fixtures/seperatejsonsections/');
   const expectedAssetOutputKey = '../sections/test-section.liquid';
+
+  // Ensure sections is in context
+  expect(
+    stats.compilation.contextDependencies.has(
+      path.resolve(__dirname, 'fixtures/seperatejsonsections/sections'),
+    ),
+  ).toBeTruthy();
+
   expect(
     stats.compilation.assets[expectedAssetOutputKey].children[0]._value,
   ).toMatchSnapshot();
@@ -51,8 +67,15 @@ test('section that has template living in folders with schema.json and no locale
 
 test('sections that have templates living in folders with a schema.json and locales to go with aswell', async () => {
   const stats = await compiler('fixtures/normalsections/');
-  // Check if file has been added to assets so webpack can output it
 
+  // Ensure sections is in context
+  expect(
+    stats.compilation.contextDependencies.has(
+      path.resolve(__dirname, 'fixtures/normalsections/sections'),
+    ),
+  ).toBeTruthy();
+
+  // Check if file has been added to assets so webpack can output it
   const expectedAssetOutputKey = '../sections/test-section.liquid';
   expect(
     stats.compilation.assets[expectedAssetOutputKey].children[0]._value,

--- a/packages/slate-sections-plugin/index.js
+++ b/packages/slate-sections-plugin/index.js
@@ -2,8 +2,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const {ConcatSource, RawSource} = require('webpack-sources');
 const _ = require('lodash');
-const SlateConfig = require('@shopify/slate-config');
-const config = new SlateConfig(require('../slate-tools/slate-tools.schema'));
 
 const DEFAULT_GENERIC_TEMPLATE_NAME = 'template.liquid';
 const PLUGIN_NAME = 'Slate Sections Plugin';
@@ -16,10 +14,7 @@ module.exports = class sectionsPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.emit.tapPromise(
-      PLUGIN_NAME,
-      this.addLocales.bind(this),
-    );
+    compiler.hooks.emit.tapPromise(PLUGIN_NAME, this.addLocales.bind(this));
 
     compiler.hooks.afterEmit.tapPromise(
       PLUGIN_NAME,
@@ -61,8 +56,8 @@ module.exports = class sectionsPlugin {
     );
   }
 
-  addSectionsToContext (compilation) {
-    compilation.contextDependencies.add(config.get('paths.theme.src.sections'));
+  addSectionsToContext(compilation) {
+    compilation.contextDependencies.add(this.options.to);
 
     return Promise.resolve({});
   }

--- a/packages/slate-sections-plugin/index.js
+++ b/packages/slate-sections-plugin/index.js
@@ -15,16 +15,15 @@ module.exports = class sectionsPlugin {
 
   apply(compiler) {
     compiler.hooks.emit.tapPromise(PLUGIN_NAME, this.addLocales.bind(this));
-
-    compiler.hooks.afterEmit.tapPromise(
-      PLUGIN_NAME,
-      this.addSectionsToContext.bind(this),
-    );
   }
 
   async addLocales(compilation) {
     const files = await fs.readdir(this.options.from);
     const compilationOutput = compilation.compiler.outputPath;
+
+    // Add sections folder to webpack context
+    compilation.contextDependencies.add(this.options.from);
+
     return Promise.all(
       files.map(async (file) => {
         const fileStat = await fs.stat(path.resolve(this.options.from, file));
@@ -54,12 +53,6 @@ module.exports = class sectionsPlugin {
         }
       }),
     );
-  }
-
-  addSectionsToContext(compilation) {
-    compilation.contextDependencies.add(this.options.to);
-
-    return Promise.resolve({});
   }
 
   _validateOptions(options) {


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
Fix a small issue introduced by https://github.com/Shopify/slate/pull/1000.

With the new Slate Sections Plugin introduction, the `sections` folder got removed from Webpack's context. I believe it was previously added there by the CopyWebpackPlugin.

This PR adds it back into the context so making changes to the files causes the browser to reload as it used to.

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/1004

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

