### PR TITLE
Fix lax checking of filename against genericTemplateName in sections plugin

### DIFF
--- a/packages/slate-sections-plugin/index.js
+++ b/packages/slate-sections-plugin/index.js
@@ -75,7 +75,10 @@ module.exports = class sectionsPlugin {
    * @returns The output file name of the liquid file.
    */
   _getOutputFileName(relativePathFromSections) {
-    if (path.basename(relativePathFromSections) === this.options.genericTemplateName) {
+    if (
+      path.basename(relativePathFromSections) ===
+      this.options.genericTemplateName
+    ) {
       const sectionName = relativePathFromSections.split(path.sep)[0];
       return `${sectionName}.liquid`;
     }

--- a/packages/slate-sections-plugin/index.js
+++ b/packages/slate-sections-plugin/index.js
@@ -75,7 +75,7 @@ module.exports = class sectionsPlugin {
    * @returns The output file name of the liquid file.
    */
   _getOutputFileName(relativePathFromSections) {
-    if (relativePathFromSections.includes(this.options.genericTemplateName)) {
+    if (path.basename(relativePathFromSections) === this.options.genericTemplateName) {
       const sectionName = relativePathFromSections.split(path.sep)[0];
       return `${sectionName}.liquid`;
     }


### PR DESCRIPTION
The sections plugin was performing a lax check on the section filename against the genericTemplateName option, using the `includes()` method to see if the `relativePathFromSections` argument includes the `genericTemplateName` option value _anywhere_ within it.

This meant files such as `src/sections/collection-template.liquid` were compiled to `dist/sections/collection-template.liquid.liquid` and were not being updated on Shopify when changes were made locally with `yarn start` running.

This fix compares the basename of the `relativePathFromSections` argument instead.

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

