### PR TITLE
Implement --liveDeploy

### DIFF
--- a/docs/v1/versioned_docs/version-1.0.0-beta.14/Commands.md
+++ b/docs/v1/versioned_docs/version-1.0.0-beta.14/Commands.md
@@ -80,16 +80,17 @@ slate-tools lint [--scripts] [--styles] [--locales]
 Compiles your local theme files into a `dist` directory, uploads these files to your remote Shopify store and finally boots up a local Express server that will serve most of your CSS and JavaScript.
 
 ```bash
-slate-tools start [--env=my-custom-env-name] [--skipPrompts] [--skipFirstDeploy]
+slate-tools start [--env=my-custom-env-name] [--skipPrompts] [--skipFirstDeploy] [--liveDeploy]
 ```
 
 | Flag                | Description                                                                                           |
 | ------------------- | ----------------------------------------------------------------------------------------------------- |
 | `--env`             | Targets a custom environment file. Setting `--env=production` would use the `.env.production` file    |
+| `--liveDeploy`             | Disables the local Express server (and hot reloading), serving all assets through the Shopify CDN |
 | `--skipPrompts`     | Skips all prompts. This is especially useful when using Slate Tools with continuous integration tools |
 | `--skipFirstDeploy` | Skips the file upload sequence and simply boots up the local Express server                           |
 
-> ⚠️ Because your CSS and JavaScript assets are being served locally, your theme won’t function on any device outside your network. You want to [deploy](#deploy) your assets anytime your theme updates are finalized using `slate-tools build && slate-tools deploy`.
+> ⚠️ Without the `--liveDeploy` flag set, your CSS and JavaScript assets are being served locally, and your theme won’t function on any device outside your network. Regardless, you should [deploy](#deploy) your assets anytime your theme updates are finalized using `slate-tools build && slate-tools deploy`.
 
 ## zip
 

--- a/packages/slate-tools/cli/commands/start.js
+++ b/packages/slate-tools/cli/commands/start.js
@@ -48,6 +48,7 @@ Promise.all([
     assetServer = new AssetServer({
       env: argv.env,
       skipFirstDeploy: argv.skipFirstDeploy,
+      liveDeploy: argv.liveDeploy,
       webpackConfig,
       port: ports[1],
       address,

--- a/packages/slate-tools/tools/asset-server/index.js
+++ b/packages/slate-tools/tools/asset-server/index.js
@@ -21,8 +21,8 @@ module.exports = class DevServer {
 
     if (!this.options.liveDeploy) {
       options.webpackConfig.plugins.push(
-        new webpack.HotModuleReplacementPlugin()
-      )
+        new webpack.HotModuleReplacementPlugin(),
+      );
     }
 
     this.compiler = webpack(options.webpackConfig);

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -18,8 +18,7 @@ const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-ch
 const config = new SlateConfig(require('../../../slate-tools.schema'));
 
 // add hot-reload related code to entry chunks if not liveDeploy
-const liveDeploy = require('minimist')(process.argv.slice(2)).liveDeploy
-if (!liveDeploy) {
+if (!argv.liveDeploy) {
   Object.keys(entry.entry).forEach((name) => {
     entry.entry[name] = [path.join(__dirname, '../hot-client.js')].concat(
       entry.entry[name],

--- a/packages/slate-tools/tools/webpack/config/dev.js
+++ b/packages/slate-tools/tools/webpack/config/dev.js
@@ -1,3 +1,4 @@
+const argv = require('minimist')(process.argv.slice(2));
 const path = require('path');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
@@ -16,12 +17,15 @@ const getTemplateEntrypoints = require('./utilities/get-template-entrypoints');
 const HtmlWebpackIncludeLiquidStylesPlugin = require('../html-webpack-include-chunks');
 const config = new SlateConfig(require('../../../slate-tools.schema'));
 
-// add hot-reload related code to entry chunks
-Object.keys(entry.entry).forEach((name) => {
-  entry.entry[name] = [path.join(__dirname, '../hot-client.js')].concat(
-    entry.entry[name],
-  );
-});
+// add hot-reload related code to entry chunks if not liveDeploy
+const liveDeploy = require('minimist')(process.argv.slice(2)).liveDeploy
+if (!liveDeploy) {
+  Object.keys(entry.entry).forEach((name) => {
+    entry.entry[name] = [path.join(__dirname, '../hot-client.js')].concat(
+      entry.entry[name],
+    );
+  });
+}
 
 module.exports = merge([
   core,
@@ -35,8 +39,6 @@ module.exports = merge([
     devtool: '#eval-source-map',
 
     plugins: [
-      new webpack.HotModuleReplacementPlugin(),
-
       new HtmlWebpackPlugin({
         excludeChunks: ['static'],
         filename: `../snippets/script-tags.liquid`,
@@ -46,7 +48,7 @@ module.exports = merge([
           removeComments: true,
           removeAttributeQuotes: false,
         },
-        isDevServer: true,
+        isDevServer: !argv.liveDeploy,
         liquidTemplates: getTemplateEntrypoints(),
         liquidLayouts: getLayoutEntrypoints(),
       }),
@@ -64,7 +66,7 @@ module.exports = merge([
         },
         // necessary to consistently work with multiple chunks via CommonsChunkPlugin
         chunksSortMode: 'dependency',
-        isDevServer: true,
+        isDevServer: !argv.liveDeploy,
         liquidTemplates: getTemplateEntrypoints(),
         liquidLayouts: getLayoutEntrypoints(),
       }),


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Currently, Slate serves all CSS/JS from a local server. This is amazing, but it makes it very difficult to develop with a remote client. This PR adds a flag `--liveDeploy` that indicates that `slate-tools` should not serve assets locally, but rather through the Shopify CDN.

Related: #905 


### Checklist
For contributors:
- [X] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

