### PR TITLE
Fix installation step

### DIFF
--- a/packages/slate-sections-plugin/README.md
+++ b/packages/slate-sections-plugin/README.md
@@ -27,7 +27,7 @@ const slateSectionsOptions = {
 };
 
 module.exports = {
-  plugins: [new SlateSectionsPlugin({slateSectionsOptions})],
+  plugins: [new SlateSectionsPlugin(slateSectionsOptions)],
 };
 ```
 


### PR DESCRIPTION
In part where we connect slate-section-plugin to the Webpack there are more curly brackets than needed. 

```
module.exports = {
  plugins: [new SlateSectionsPlugin({slateSectionsOptions})],
};
```
should be: 
```
module.exports = {
  plugins: [new SlateSectionsPlugin(slateSectionsOptions)],
};
```

### This repo is currently on low maintenance. See README for details

### What are you trying to accomplish with this PR?

*Please provide a link to the associated GitHub issue.*

> No issue relevant.


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.

