### PR TITLE
Disable HSTS for dev server

### DIFF
--- a/packages/slate-tools/tools/dev-server/index.js
+++ b/packages/slate-tools/tools/dev-server/index.js
@@ -30,11 +30,11 @@ class DevServer {
           next();
         },
         proxyRes: [
-            function(proxyRes, req, res) {
-                // disable HSTS. Slate might force us to use HTTPS but having HSTS on local dev makes it impossible to do other non-Slate dev.
-                delete proxyRes.headers['strict-transport-security'];
-            }
-        ]
+          function(proxyRes) {
+            // disable HSTS. Slate might force us to use HTTPS but having HSTS on local dev makes it impossible to do other non-Slate dev.
+            delete proxyRes.headers['strict-transport-security'];
+          },
+        ],
       },
       https: {key: getSSLKeyPath(), cert: getSSLCertPath()},
       logLevel: 'silent',

--- a/packages/slate-tools/tools/dev-server/index.js
+++ b/packages/slate-tools/tools/dev-server/index.js
@@ -29,6 +29,12 @@ class DevServer {
           req.url += prefix + queryStringComponents.join('&');
           next();
         },
+        proxyRes: [
+            function(proxyRes, req, res) {
+                // disable HSTS. Slate might force us to use HTTPS but having HSTS on local dev makes it impossible to do other non-Slate dev.
+                delete proxyRes.headers['strict-transport-security'];
+            }
+        ]
       },
       https: {key: getSSLKeyPath(), cert: getSSLCertPath()},
       logLevel: 'silent',


### PR DESCRIPTION
Most other non-Slate 1.x development is via HTTP so by having HSTS on it really makes Shopify development tricky.

### This repo is currently on low maintenance. See README for details

### What are you trying to accomplish with this PR?

Most non-Shopify Slate 1.x development is done via HTTP. By leaving on Shopify's HSTS policy, it forces any localhost visits to happen via HTTPS. This simply removes that header from Shopify's proxied response so that HTTPS and HTTP can be used on localhost without issue.

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/906


### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

