### PR TITLE
Update themekit to 1.1.2, support section themes

### DIFF
--- a/packages/slate-config/common/paths.schema.js
+++ b/packages/slate-config/common/paths.schema.js
@@ -39,6 +39,22 @@ module.exports = {
   'paths.theme.src.snippets': (config) =>
     path.join(config.get('paths.theme.src'), 'snippets'),
 
+  // Source snippets directory
+  'paths.theme.src.frame': (config) =>
+    path.join(config.get('paths.theme.src'), 'frame'),
+
+  // Source snippets directory
+  'paths.theme.src.content': (config) =>
+    path.join(config.get('paths.theme.src'), 'content'),
+
+  // Source snippets directory
+  'paths.theme.src.pages': (config) =>
+    path.join(config.get('paths.theme.src'), 'pages'),
+
+  // Source snippets directory
+  'paths.theme.src.pages.customers': (config) =>
+    path.join(config.get('paths.theme.src.pages'), 'customers'),
+
   // Static asset directory for files that statically copied to paths.theme.dist.assets
   'paths.theme.src.sections': (config) =>
     path.join(config.get('paths.theme.src'), 'sections'),
@@ -81,6 +97,18 @@ module.exports = {
   // Distribution templates directory
   'paths.theme.dist.templates': (config) =>
     path.join(config.get('paths.theme.dist'), 'templates'),
+
+    // Source snippets directory
+  'paths.theme.dist.frame': (config) =>
+      path.join(config.get('paths.theme.dist'), 'frame'),
+  
+    // Source snippets directory
+  'paths.theme.dist.content': (config) =>
+      path.join(config.get('paths.theme.dist'), 'content'),
+  
+    // Source snippets directory
+  'paths.theme.dist.pages': (config) =>
+      path.join(config.get('paths.theme.dist'), 'pages'),
 
   // Directory for storing all temporary and/or cache files
   'paths.theme.cache': (config) =>

--- a/packages/slate-sync/package.json
+++ b/packages/slate-sync/package.json
@@ -14,7 +14,7 @@
     "@shopify/slate-analytics": "1.0.0-beta.16",
     "@shopify/slate-config": "1.0.0-beta.14",
     "@shopify/slate-env": "1.0.0-beta.16",
-    "@shopify/themekit": "0.6.12",
+    "@shopify/themekit": "1.1.2",
     "array-flatten": "^2.1.1",
     "chalk": "2.3.2",
     "figures": "^2.0.0",

--- a/packages/slate-tools/package.json
+++ b/packages/slate-tools/package.json
@@ -24,7 +24,7 @@
     "@shopify/slate-tag-webpack-plugin": "1.0.0-beta.14",
     "@shopify/slate-translations": "1.0.0-beta.19",
     "@shopify/theme-lint": "^2.0.0",
-    "@shopify/themekit": "0.6.12",
+    "@shopify/themekit": "1.1.2",
     "archiver": "^2.1.0",
     "array-flatten": "^2.1.1",
     "autoprefixer": "6.7.7",

--- a/packages/slate-tools/tools/webpack/config/parts/core.js
+++ b/packages/slate-tools/tools/webpack/config/parts/core.js
@@ -105,6 +105,18 @@ module.exports = {
         from: config.get('paths.theme.src.templates'),
         to: config.get('paths.theme.dist.templates'),
       },
+      {
+        from: config.get('paths.theme.src.pages'),
+        to: config.get('paths.theme.dist.pages'),
+      },
+      {
+        from: config.get('paths.theme.src.content'),
+        to: config.get('paths.theme.dist.content'),
+      },
+      {
+        from: config.get('paths.theme.src.frame'),
+        to: config.get('paths.theme.dist.frame'),
+      },
     ]),
 
     new SlateSectionsPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,10 +1173,10 @@
     htmllint "^0.6.0"
     lodash "^4.15.0"
 
-"@shopify/themekit@0.6.12":
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/@shopify/themekit/-/themekit-0.6.12.tgz#7cf86175b3b62ef7f405f068fd6f7c0cc8fd30bc"
-  integrity sha512-8yzAoXACUvAJEZU7vpcIGZcMayHcvwMqEc2XKKSSqZN7HHD1VMbogepMb/8h6jZ0xFUHH0IQSpT0sKZfAKDMrw==
+"@shopify/themekit@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@shopify/themekit/-/themekit-1.1.2.tgz#658a54a9b933ffb13015f5e4eae8a10b4d704bd7"
+  integrity sha512-+/iu/U4UHDM0VmPfx0dgj7mtjSD5QS09JOnS1Lz9iitxzKl/YdZ0GwnJK0plmt5TxqRpzFK5hYbM9DYBnto9Bg==
   dependencies:
     bin-wrapper "3.0.2"
     minimist "1.2.0"


### PR DESCRIPTION
### This repo is currently on low maintenance. See README for details

### What are you trying to accomplish with this PR?
Upgrade node-themekit to 1.1.2 offering support for /pages, /content, and /frame directories.

*Please provide a link to the associated GitHub issue.*
https://github.com/Shopify/slate/issues/1057
https://github.com/Shopify/slate/issues/1054

### Checklist
For contributors:
- [ ] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

