### PR TITLE
Add Linux/Ubuntu ssl-check shell function instructions

### DIFF
--- a/docs/v1/versioned_docs/version-1.0.0-beta.14/Create-a-self-signed-SSL-certificate.md
+++ b/docs/v1/versioned_docs/version-1.0.0-beta.14/Create-a-self-signed-SSL-certificate.md
@@ -64,7 +64,7 @@ function ssl-check() {
 ```
 
 ### Linux/Ubuntu
-```
+```bash
 function ssl-check() {
          f=~/.localhost_ssl;
          ssl_crt=$f/server.crt

--- a/docs/v1/versioned_docs/version-1.0.0-beta.14/Create-a-self-signed-SSL-certificate.md
+++ b/docs/v1/versioned_docs/version-1.0.0-beta.14/Create-a-self-signed-SSL-certificate.md
@@ -1,4 +1,3 @@
-
 ---
 id: version-1.0.0-beta.14-create-a-self-signed-ssl-certificate
 title: Create a self-signed SSL certificate


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Add a Linux-specific ssl-check bash function. The Mac one provided doesn't work on WSL/Ubuntu setups.

### Checklist
For contributors:
- [x] I have [updated the docs](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.

