### PR TITLE
GCOM-920: Shopify Slate Enhancements

### DIFF
--- a/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
+++ b/packages/slate-tools/tools/webpack/config/utilities/get-template-entrypoints.js
@@ -4,65 +4,71 @@ const SlateConfig = require('@shopify/slate-config');
 const config = new SlateConfig(require('../../../../slate-tools.schema'));
 
 const VALID_LIQUID_TEMPLATES = [
-  '404',
-  'article',
-  'blog',
-  'cart',
-  'collection',
-  'account',
-  'activate_account',
-  'addresses',
-  'login',
-  'order',
-  'register',
-  'reset_password',
-  'gift_card',
-  'index',
-  'list-collections',
-  'page',
-  'password',
-  'product',
-  'search',
+  '404',
+  'article',
+  'blog',
+  'cart',
+  'collection',
+  'account',
+  'activate_account',
+  'addresses',
+  'login',
+  'order',
+  'register',
+  'reset_password',
+  'gift_card',
+  'index',
+  'list-collections',
+  'page',
+  'password',
+  'product',
+  'search',
 ];
 
 function isValidTemplate(filename) {
-  const name = VALID_LIQUID_TEMPLATES.filter((template) =>
-    filename.startsWith(`${template}.`),
-  );
-  return Boolean(name);
+  const name = VALID_LIQUID_TEMPLATES.filter((template) =>
+    filename.startsWith(`${template}.`),
+  );
+  return Boolean(name);
 }
 
 module.exports = function() {
-  const entrypoints = {};
+  const entrypoints = {};
 
-  fs.readdirSync(config.get('paths.theme.src.templates')).forEach((file) => {
-    const name = path.parse(file).name;
-    const jsFile = path.join(
-      config.get('paths.theme.src.scripts'),
-      'templates',
-      `${name}.js`,
-    );
+  fs.readdirSync(config.get('paths.theme.src.templates')).forEach((file) => {
+    const name = path.parse(file).name;
+    const jsFile = path.join(
+      config.get('paths.theme.src.scripts'),
+      'templates',
+      `${name}.js`,
+    );
 
-    if (isValidTemplate(name) && fs.existsSync(jsFile)) {
-      entrypoints[`template.${name}`] = jsFile;
-    }
-  });
+    if ((isValidTemplate(name) && fs.existsSync(jsFile) && !name.includes('product')) || (isValidTemplate(name) && fs.existsSync(jsFile) && name == 'product')) {
+      entrypoints[`template.${name}`] = jsFile;
+    } else if (isValidTemplate(name) && fs.existsSync(jsFile) && name.includes('product') && name !== 'product') {
+      entrypoints[`template.${name}`] = [jsFile, path.join(
+        config.get('paths.theme.src.scripts'),
+        'templates',
+        `product.js`,
+      )];
+    } 
+  });
 
-  fs
-    .readdirSync(config.get('paths.theme.src.templates.customers'))
-    .forEach((file) => {
-      const name = `${path.parse(file).name}`;
-      const jsFile = path.join(
-        config.get('paths.theme.src.scripts'),
-        'templates',
-        'customers',
-        `${name}.js`,
-      );
+  fs
+    .readdirSync(config.get('paths.theme.src.templates.customers'))
+    .forEach((file) => {
+      const name = `${path.parse(file).name}`;
+      const jsFile = path.join(
+        config.get('paths.theme.src.scripts'),
+        'templates',
+        'customers',
+        `${name}.js`,
+      );
 
-      if (isValidTemplate(name) && fs.existsSync(jsFile)) {
-        entrypoints[`template.${name}`] = jsFile;
-      }
-    });
+      if (isValidTemplate(name) && fs.existsSync(jsFile)) {
+        entrypoints[`template.${name}`] = jsFile;
+      }
+    });
 
-  return entrypoints;
+  return entrypoints;
 };


### PR DESCRIPTION
Shopify Slate Enhancements

Modified webpack entry points for slate-tools to allow parent template scripts across all template variations. For example, product.js script will be available on product.custom.liquid as well as product.liquid. 

We can have parent/global scripts for all template types (ie: product, page, collection)
We can have a unique template to not inherit their parent script: (<template_type>.unique.<name>.liquid